### PR TITLE
fix(tools): inclusive corners for rectangle, sprite-global pixel reads

### DIFF
--- a/aseprite_mcp/tools/drawing.py
+++ b/aseprite_mcp/tools/drawing.py
@@ -165,18 +165,25 @@ async def draw_rectangle(filename: str, x: int, y: int, width: int, height: int,
         filename: Name of the Aseprite file to modify
         x: Top-left x coordinate
         y: Top-left y coordinate
-        width: Width of the rectangle
-        height: Height of the rectangle
+        width: Width of the rectangle in pixels (must be > 0)
+        height: Height of the rectangle in pixels (must be > 0)
         color: Hex color code (default: "#000000")
         fill: Whether to fill the rectangle (default: False)
     """
     if not os.path.exists(filename):
         return f"File {filename} not found"
+    if width <= 0 or height <= 0:
+        return "Width and height must be > 0"
 
     rgb = _parse_hex_color(color)
     if rgb is None:
         return f"Invalid color value: {color}"
     r, g, b = rgb
+
+    # app.useTool treats both points as inclusive corners, so the second
+    # point sits at (x+width-1, y+height-1) for a width x height rect.
+    x2 = x + width - 1
+    y2 = y + height - 1
 
     script = f"""
     local spr = app.activeSprite
@@ -198,7 +205,7 @@ async def draw_rectangle(filename: str, x: int, y: int, width: int, height: int,
         app.useTool({{
             tool=tool,
             color=color,
-            points={{Point({x}, {y}), Point({x + width}, {y + height})}}
+            points={{Point({x}, {y}), Point({x2}, {y2})}}
         }})
     end)
 
@@ -496,6 +503,8 @@ async def draw_rectangle_at(
     """Draw a rectangle on a specific layer/frame."""
     if not os.path.exists(filename):
         return f"File {filename} not found"
+    if width <= 0 or height <= 0:
+        return "Width and height must be > 0"
 
     rgb = _parse_hex_color(color)
     if rgb is None:
@@ -503,6 +512,8 @@ async def draw_rectangle_at(
     r, g, b = rgb
     safe_layer_name = lua_escape(layer_name)
     create_flag = "true" if create_if_missing else "false"
+    x2 = x + width - 1
+    y2 = y + height - 1
 
     script = f"""
     local spr = app.activeSprite
@@ -531,7 +542,7 @@ async def draw_rectangle_at(
         app.useTool({{
             tool=tool,
             color=color,
-            points={{Point({x}, {y}), Point({x + width}, {y + height})}}
+            points={{Point({x}, {y}), Point({x2}, {y2})}}
         }})
     end)
 

--- a/aseprite_mcp/tools/pixel_read.py
+++ b/aseprite_mcp/tools/pixel_read.py
@@ -32,28 +32,33 @@ async def get_pixel_color(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local img = nil
+    local cel = nil
     if "{safe_layer}" ~= "" then
         local target = nil
         for _, layer in ipairs(spr.layers) do
             if layer.name == "{safe_layer}" then target = layer break end
         end
         if not target then print("ERROR:Layer not found") return end
-        local cel = target:cel(spr.frames[idx])
+        cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end
-        img = cel.image
     else
         app.activeFrame = spr.frames[idx]
-        local cel = app.activeCel
+        cel = app.activeCel
         if not cel then print("ERROR:No active cel") return end
-        img = cel.image
     end
 
-    local px_val = img:getPixel({x}, {y})
-    local r = app.pixelColor.rgbaR(px_val)
-    local g = app.pixelColor.rgbaG(px_val)
-    local b = app.pixelColor.rgbaB(px_val)
-    local a = app.pixelColor.rgbaA(px_val)
+    local img = cel.image
+    -- Coordinates are sprite-global; offset into cel-local space.
+    local cx = {x} - cel.position.x
+    local cy = {y} - cel.position.y
+    local r, g, b, a = 0, 0, 0, 0
+    if cx >= 0 and cy >= 0 and cx < img.width and cy < img.height then
+        local px_val = img:getPixel(cx, cy)
+        r = app.pixelColor.rgbaR(px_val)
+        g = app.pixelColor.rgbaG(px_val)
+        b = app.pixelColor.rgbaB(px_val)
+        a = app.pixelColor.rgbaA(px_val)
+    end
     print(string.format("PIXEL:%d,%d,%d,%d", r, g, b, a))
     """
 
@@ -112,30 +117,39 @@ async def get_pixels_rect(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local img = nil
+    local cel = nil
     if "{safe_layer}" ~= "" then
         local target = nil
         for _, layer in ipairs(spr.layers) do
             if layer.name == "{safe_layer}" then target = layer break end
         end
         if not target then print("ERROR:Layer not found") return end
-        local cel = target:cel(spr.frames[idx])
+        cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end
-        img = cel.image
     else
         app.activeFrame = spr.frames[idx]
-        local cel = app.activeCel
+        cel = app.activeCel
         if not cel then print("ERROR:No active cel") return end
-        img = cel.image
     end
+
+    local img = cel.image
+    local ox = cel.position.x
+    local oy = cel.position.y
+    local iw = img.width
+    local ih = img.height
 
     for py = {y}, {y_end} do
         for px = {x}, {x_end} do
-            local px_val = img:getPixel(px, py)
-            local r = app.pixelColor.rgbaR(px_val)
-            local g = app.pixelColor.rgbaG(px_val)
-            local b = app.pixelColor.rgbaB(px_val)
-            local a = app.pixelColor.rgbaA(px_val)
+            local cx = px - ox
+            local cy = py - oy
+            local r, g, b, a = 0, 0, 0, 0
+            if cx >= 0 and cy >= 0 and cx < iw and cy < ih then
+                local px_val = img:getPixel(cx, cy)
+                r = app.pixelColor.rgbaR(px_val)
+                g = app.pixelColor.rgbaG(px_val)
+                b = app.pixelColor.rgbaB(px_val)
+                a = app.pixelColor.rgbaA(px_val)
+            end
             print(string.format("PIXEL:%d,%d,%d,%d,%d,%d", px, py, r, g, b, a))
         end
     end


### PR DESCRIPTION
## Summary

Fixes two coordinate-handling bugs in `drawing.py` and `pixel_read.py` that produce visibly wrong output on the most common use cases.

### 1. `draw_rectangle` / `draw_rectangle_at` — off-by-one size

`app.useTool` treats both `points` as **inclusive** corners. The current code:

```python
points={{Point({x}, {y}), Point({x + width}, {y + height})}}
```

actually draws a `(width+1) × (height+1)` rectangle. Asking for a 12×12 rect produces a 13×13 one.

Fix: send `Point(x+width-1, y+height-1)` so that the requested `width × height` is honored, and validate `width > 0`, `height > 0`.

### 2. `get_pixel_color` / `get_pixels_rect` — coordinates were cel-local, not sprite-global

The docstrings describe the inputs as plain `x` / `y` coordinates, suggesting sprite space. But the Lua calls `cel.image:getPixel(x, y)` directly, which uses **cel-local** coordinates.

After `app.useTool` runs (e.g. via `draw_rectangle`), Aseprite trims the cel to the drawn region and `cel.position` becomes non-zero. Reads at the same sprite coordinate now hit a different region of the cel image — the rectangle appears shifted, or out-of-bounds reads return surprising values.

Fix: translate the requested coordinates into the cel's local space using `cel.position`, and return transparent `(0,0,0,0)` for coordinates that fall outside the cel image bounds.

## Repro

On a fresh 16×16 canvas:

```
draw_rectangle(filename, x=2, y=2, width=12, height=12, color="#ff0000", fill=True)
```

**Before this PR**
- `cel.position = (2, 2)`, `cel.image` is 13×13, 169 red pixels
- `get_pixels_rect(0, 0, 16, 16)` reports the red region at sprite `(0,0)-(12,12)`

**After this PR**
- `cel.position = (2, 2)`, `cel.image` is 12×12, 144 red pixels
- `get_pixels_rect(0, 0, 16, 16)` reports the red region at sprite `(2,2)-(13,13)`

## Notes

- I noticed similar bugs (e.g. `img:putPixel(x, y, ...)` without `cel.position` offset in `draw_pixels`, `draw_pixels_at`, and the manual Bresenham path in `draw_line`). I'm keeping this PR small and focused on the read tools + the rectangle off-by-one; happy to follow up on the write side in a separate PR if you'd prefer.
- The ellipse `radius` semantics (`Point(cx-r, cy-r), Point(cx+r, cy+r)` → diameter `2r+1`) are conventional for pixel art and not changed here, but the same geometry inconsistency could be revisited if you want `radius` to mirror the rectangle's `width / height` semantics.

## Test plan

- [x] Empirically verified on a 16×16 canvas with `draw_rectangle(2, 2, 12, 12, fill=True)` — pixel count and bbox match expectations after fix.
- [x] `get_pixels_rect` over a region that extends past the cel returns transparent for the gap, opaque inside.
- [ ] Maintainer to verify against any existing test harness.