### PR TITLE
fix(security): escape copy_sprite filename + harden traversal check

### DIFF
--- a/aseprite_mcp/core/commands.py
+++ b/aseprite_mcp/core/commands.py
@@ -18,6 +18,24 @@ def lua_escape(s: str) -> str:
     )
 
 
+def reject_traversal(path: str) -> str | None:
+    """Reject parent-directory traversal in a user-supplied path.
+
+    Returns an error message string when the path contains a `..`
+    component, or None when the path looks safe.
+
+    The check works on normalized path components, so it does not
+    false-positive on filenames like `foo..bar.aseprite` (the previous
+    `'..' in path` substring check did). Absolute paths and tilde
+    expansion are not rejected here: this function targets traversal
+    only, not access scoping.
+    """
+    parts = os.path.normpath(path).replace("\\", "/").split("/")
+    if ".." in parts:
+        return "Invalid filename: parent directory traversal not allowed"
+    return None
+
+
 class AsepriteCommand:
     """Helper class for running Aseprite commands."""
     

--- a/aseprite_mcp/tools/canvas.py
+++ b/aseprite_mcp/tools/canvas.py
@@ -1,5 +1,5 @@
 import os
-from ..core.commands import AsepriteCommand, lua_escape
+from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
 from .. import mcp
 
 @mcp.tool()
@@ -13,8 +13,9 @@ async def create_canvas(width: int, height: int, filename: str = "canvas.aseprit
     """
     if width <= 0 or height <= 0:
         return "Width and height must be > 0"
-    if ".." in filename:
-        return "Invalid filename: path traversal not allowed"
+    err = reject_traversal(filename)
+    if err:
+        return err
 
     safe_path = lua_escape(filename.replace("\\", "/"))
     script = f"""

--- a/aseprite_mcp/tools/export.py
+++ b/aseprite_mcp/tools/export.py
@@ -1,5 +1,5 @@
 import os
-from ..core.commands import AsepriteCommand
+from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
 from .. import mcp
 
 @mcp.tool()
@@ -50,10 +50,14 @@ async def copy_sprite(filename: str, output_filename: str, overwrite: bool = Fal
     if not output_filename.lower().endswith(".aseprite"):
         output_filename = f"{output_filename}.aseprite"
 
+    err = reject_traversal(output_filename)
+    if err:
+        return err
+
     if os.path.exists(output_filename) and not overwrite:
         return f"Output file {output_filename} already exists"
 
-    safe_path = output_filename.replace("\\", "/")
+    safe_path = lua_escape(output_filename.replace("\\", "/"))
     script = f"""
     local spr = app.activeSprite
     if not spr then return "No active sprite" end

--- a/aseprite_mcp/tools/scene.py
+++ b/aseprite_mcp/tools/scene.py
@@ -1,6 +1,6 @@
 import os
 from typing import List
-from ..core.commands import AsepriteCommand, lua_escape
+from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
 from .. import mcp
 
 @mcp.tool()
@@ -26,8 +26,9 @@ async def copy_layers_between_sprites(
         return f"File {target_filename} not found"
     if not layer_names:
         return "Layer names list cannot be empty"
-    if ".." in source_filename or ".." in target_filename:
-        return "Invalid filename: path traversal not allowed"
+    err = reject_traversal(source_filename) or reject_traversal(target_filename)
+    if err:
+        return err
 
     src_path = lua_escape(source_filename.replace("\\", "/"))
     dst_path = lua_escape(target_filename.replace("\\", "/"))


### PR DESCRIPTION
## Summary

Two small, independent security cleanups around path handling:

### 1. `copy_sprite` was missing `lua_escape` on the output filename

Of the three tools that embed a user-supplied path inside a Lua string literal, `create_canvas` and `copy_layers_between_sprites` both go through `lua_escape`. `copy_sprite` was the outlier: it only normalized backslashes and pasted the result directly into the Lua source.

A path containing a quote, backslash, or newline either breaks the generated script (best case) or injects Lua code (worst case):

\`\`\`python
copy_sprite(\"foo.aseprite\", 'evil\".aseprite\\nos.execute(\"id\")\\n--')
# → script containing: spr:saveAs(\"evil\".aseprite
# os.execute(\"id\")
# --\")
\`\`\`

Routing through `lua_escape` aligns it with the other tools.

### 2. Traversal check is now component-aware, not a substring match

The `'..' in filename` check in `canvas.py` and `scene.py` catches real traversal attempts (`../etc/passwd`) but also false-positives on ordinary filenames that happen to contain two adjacent dots (`foo..bar.aseprite`, `v1.2..3.aseprite`, ...).

A new `reject_traversal()` helper in `commands.py` normalizes the path and inspects its slash-separated components, so it catches `../`, `foo/../`, and `..\\` while letting innocent filenames with consecutive dots through. `canvas.py`, `scene.py`, and `export.py` (the new `copy_sprite` callsite) all adopt the helper.

## Repro

\`\`\`python
from aseprite_mcp.core.commands import reject_traversal

reject_traversal(\"foo..bar.aseprite\")        # None ✓ (was rejected before)
reject_traversal(\"v1.2..3.aseprite\")          # None ✓ (was rejected before)
reject_traversal(\"../../etc/passwd\")          # error ✓
reject_traversal(\"foo/../../etc/passwd\")      # error ✓
reject_traversal(\"normal/file.aseprite\")      # None ✓
reject_traversal(\"/abs/path.aseprite\")        # None (absolute paths are still allowed)
\`\`\`

## Notes

- This is just a refinement of the protection already added in #1 (`fix(security): escape Lua string injections and add path traversal protection`); same intent, fewer false positives.
- Absolute paths and tilde expansion are still allowed by `reject_traversal`. If you want the MCP server to scope writes to a base directory, that is a separate, opt-in decision (different threat model).

## Test plan

- [x] Verified `reject_traversal` returns `None` for innocent filenames and an error for real traversal attempts.
- [x] Verified `lua_escape` handles a filename containing a quote without breaking the generated Lua script.
- [ ] Maintainer to sanity-check against any existing tests.