### PR TITLE
fix(tools): get_sprite_info and audit_animation return empty in batch mode

### DIFF
--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -157,7 +157,7 @@ async def set_layer_opacity(filename: str, layer_name: str, opacity: int) -> str
 
 @mcp.tool()
 async def get_sprite_info(filename: str) -> str:
-    """Return sprite info as JSON string (size, frame count, layers).
+    """Return sprite info as JSON string (size, color mode, frame durations, layers, tags).
 
     Args:
         filename: Name of the Aseprite file to inspect
@@ -165,25 +165,46 @@ async def get_sprite_info(filename: str) -> str:
     if not os.path.exists(filename):
         return f"File {filename} not found"
 
+    # NOTE: batch mode discards Lua `return` values — output MUST go through print().
     script = """
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("No active sprite") return end
+
+    local cm = "unknown"
+    if spr.colorMode == ColorMode.RGB then cm = "rgb"
+    elseif spr.colorMode == ColorMode.INDEXED then cm = "indexed"
+    elseif spr.colorMode == ColorMode.GRAY then cm = "gray" end
 
     local parts = {}
     table.insert(parts, "{")
     table.insert(parts, "\\"width\\":" .. spr.width .. ",")
     table.insert(parts, "\\"height\\":" .. spr.height .. ",")
+    table.insert(parts, "\\"color_mode\\":\\"" .. cm .. "\\",")
     table.insert(parts, "\\"frames\\":" .. #spr.frames .. ",")
+    table.insert(parts, "\\"durations_ms\\":[")
+    for i, frame in ipairs(spr.frames) do
+        table.insert(parts, tostring(math.floor(frame.duration * 1000 + 0.5)))
+        if i < #spr.frames then table.insert(parts, ",") end
+    end
+    table.insert(parts, "],")
     table.insert(parts, "\\"layers\\":[")
     for i, layer in ipairs(spr.layers) do
-        local entry = "{\\"name\\":\\"" .. layer.name .. "\\",\\"visible\\":" .. tostring(layer.isVisible) .. ",\\"opacity\\":" .. layer.opacity .. "}"
+        local entry = "{\\"name\\":" .. string.format("%q", layer.name) .. ",\\"visible\\":" .. tostring(layer.isVisible) .. ",\\"opacity\\":" .. (layer.opacity or 255) .. ",\\"is_group\\":" .. tostring(layer.isGroup) .. "}"
         table.insert(parts, entry)
         if i < #spr.layers then
             table.insert(parts, ",")
         end
     end
+    table.insert(parts, "],")
+    local dirs = {[0]="forward", "reverse", "pingpong", "pingpong_reverse"}
+    table.insert(parts, "\\"tags\\":[")
+    for i, t in ipairs(spr.tags) do
+        local entry = "{\\"name\\":" .. string.format("%q", t.name) .. ",\\"from\\":" .. t.fromFrame.frameNumber .. ",\\"to\\":" .. t.toFrame.frameNumber .. ",\\"direction\\":\\"" .. (dirs[tonumber(t.aniDir)] or tostring(t.aniDir)) .. "\\"}"
+        table.insert(parts, entry)
+        if i < #spr.tags then table.insert(parts, ",") end
+    end
     table.insert(parts, "]}")
-    return table.concat(parts)
+    print(table.concat(parts))
     """
 
     success, output = AsepriteCommand.execute_lua_script(script, filename)

--- a/aseprite_mcp/tools/quality.py
+++ b/aseprite_mcp/tools/quality.py
@@ -437,7 +437,8 @@ async def audit_animation(
     end
 
     table.insert(parts, "}}")
-    return table.concat(parts)
+    -- batch mode discards Lua `return` values; output must be printed
+    print(table.concat(parts))
     """
 
     success, output = AsepriteCommand.execute_lua_script(script, filename)


### PR DESCRIPTION
## Problem

`get_sprite_info` and `audit_animation` always return an empty string.

Root cause: `aseprite --batch --script` **discards a Lua script's top-level `return` value** — only `print()` reaches stdout. Both tools end their Lua with `return table.concat(parts)`, so the Python wrapper receives empty stdout and passes it through. Easy to confirm: a script containing `return "X"` prints nothing in batch mode, while `print("X")` prints `X`.

The print-based tools (`validate_scene`, `animation_sanitize`, `get_pixel_color`, `get_pixels_rect`, `get_palette`) already work — this brings the two broken ones in line with them.

## Fix

`print()` the JSON instead of returning it.

While touching `get_sprite_info` (whose empty output hid how little it reported), this also extends its JSON: `color_mode`, per-frame `durations_ms`, per-layer `is_group`, and `tags` (name/from/to/direction). Names are emitted via `string.format('%q')` so quotes/backslashes can't break the JSON. Happy to drop the extension and keep the pure print-fix if you prefer a minimal diff.

## Verification

Tested end-to-end over MCP stdio against Aseprite 1.3.17.2 (Steam, Linux, headless). Sample output on a 4-frame test file:

```json
{"width":64,"height":64,"color_mode":"rgb","frames":4,"durations_ms":[100,125,125,125],"layers":[{"name":"Layer 1","visible":true,"opacity":255,"is_group":false},{"name":"BASE","visible":true,"opacity":255,"is_group":false}],"tags":[{"name":"loop","from":1,"to":4,"direction":"pingpong"}]}
```

`audit_animation` now returns its full report (summary/overlaps/out_of_range/cels) on the same file.

Related: the same exit-0/return-swallowing mechanism makes several mutating tools report success on invalid input — filed separately with details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)