### PR TITLE
fix(animation): copy_cel(replace=true) deletes the destination cel without copying

### DIFF
--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -602,6 +602,7 @@ async def copy_cel(
         local dst = target:cel(spr.frames[dst_idx])
         if dst and {replace_flag} then
             spr:deleteCel(dst)
+            dst = nil
         end
         if not dst then
             local img = src.image:clone()


### PR DESCRIPTION
## Problem

`copy_cel` onto a frame that **already has a cel** with `replace=true` destroys the destination and copies nothing, while reporting `Cel copied` — silent data loss.

Root cause in the generated Lua:

```lua
local dst = target:cel(spr.frames[dst_idx])
if dst and true then
    spr:deleteCel(dst)        -- cel deleted, but local 'dst' still non-nil
end
if not dst then               -- never taken
    ...newCel(...)
end
```

Copying onto an empty destination frame works fine — only the replace path is broken.

## Fix

Reset `dst = nil` after `deleteCel`, so the copy branch executes.

## Verification

Aseprite 1.3.17.2 (Steam, Linux, headless), over MCP stdio: drew distinct pixels on frames 1 and 2 of layer BASE, ran `copy_cel(1→2, replace=true)`, then read back with `get_pixel_color`: frame 2 now holds frame 1's pixel (and the old frame-2 pixel is gone, as replace implies). Before the fix the destination cel simply vanished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)