### PR TITLE
feat(animation): set_tag honors the direction parameter (tag.aniDir)

### DIFF
--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -758,9 +758,21 @@ async def set_tag(
     to_frame: int,
     direction: str = "forward"
 ) -> str:
-    """Create or update an animation tag on the sprite."""
+    """Create or update an animation tag on the sprite.
+
+    direction: forward | reverse | pingpong | pingpong_reverse
+    """
     if not os.path.exists(filename):
         return f"File {filename} not found"
+
+    ani_dirs = {
+        "forward": "AniDir.FORWARD",
+        "reverse": "AniDir.REVERSE",
+        "pingpong": "AniDir.PING_PONG",
+        "pingpong_reverse": "AniDir.PING_PONG_REVERSE",
+    }
+    if direction not in ani_dirs:
+        return f"Unsupported direction '{direction}' (forward, reverse, pingpong, pingpong_reverse)"
 
     safe_name = lua_escape(name)
     script = f"""
@@ -784,6 +796,7 @@ async def set_tag(
         tag.toFrame = spr.frames[end_idx]
     end
     tag.name = "{safe_name}"
+    tag.aniDir = {ani_dirs[direction]}
 
     spr:saveAs(spr.filename)
     return "Tag set"
@@ -791,9 +804,7 @@ async def set_tag(
 
     success, output = AsepriteCommand.execute_lua_script(script, filename)
     if success:
-        if direction != "forward":
-            return f"Tag '{name}' set to frames {from_frame}-{to_frame} in {filename} (direction ignored)"
-        return f"Tag '{name}' set to frames {from_frame}-{to_frame} in {filename}"
+        return f"Tag '{name}' set to frames {from_frame}-{to_frame} (direction={direction}) in {filename}"
     return f"Failed to set tag: {output}"
 
 @mcp.tool()


### PR DESCRIPTION
## Problem

`set_tag` accepts a `direction` argument but never applies it: the generated Lua never sets `tag.aniDir`, and the wrapper appends `(direction ignored)` for any non-forward value. Ping-pong / reverse loops can't be expressed through the MCP — even though downstream importers (e.g. godot-aseprite-wizard) read `aniDir` from the `.aseprite` file.

## Change

- Map `direction` → `AniDir`: `forward` / `reverse` / `pingpong` / `pingpong_reverse`
- Reject unknown values up front with the accepted list (instead of silently ignoring)
- Success message reports the applied direction

## Verification

Aseprite 1.3.17.2 (Steam, Linux, headless), over MCP stdio: created tags with all four directions, re-read the saved file — `aniDir` 0/1/2/3 all persist; `direction="bounce"` is rejected with the accepted list. (Read-back done with a Lua dump; pairs with #12 which makes `get_sprite_info` report tag directions directly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)