### PR TITLE
fix(tools): propagate Lua-side errors so mutating tools stop reporting false success (#15)

### DIFF
--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -24,7 +24,7 @@ async def add_frames(filename: str, count: int, duration_ms: int | None = None) 
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         for i = 1, {count} do
@@ -34,10 +34,10 @@ async def add_frames(filename: str, count: int, duration_ms: int | None = None) 
     end)
 
     spr:saveAs(spr.filename)
-    return "Frames added"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Added {count} frames to {filename}"
     return f"Failed to add frames: {output}"
@@ -57,7 +57,7 @@ async def set_frame_duration_all(filename: str, duration_ms: int) -> str:
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         for i = 1, #spr.frames do
@@ -66,10 +66,10 @@ async def set_frame_duration_all(filename: str, duration_ms: int) -> str:
     end)
 
     spr:saveAs(spr.filename)
-    return "Frame durations set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Set duration of all frames to {duration_ms}ms in {filename}"
     return f"Failed to set frame durations: {output}"
@@ -90,7 +90,7 @@ async def set_layer_visibility(filename: str, layer_name: str, visible: bool = T
     visible_flag = "true" if visible else "false"
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target = nil
     for i, layer in ipairs(spr.layers) do
@@ -99,17 +99,17 @@ async def set_layer_visibility(filename: str, layer_name: str, visible: bool = T
             break
         end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         target.isVisible = {visible_flag}
     end)
 
     spr:saveAs(spr.filename)
-    return "Layer visibility set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Layer '{layer_name}' visibility set to {visible} in {filename}"
     return f"Failed to set layer visibility: {output}"
@@ -131,7 +131,7 @@ async def set_layer_opacity(filename: str, layer_name: str, opacity: int) -> str
     safe_layer_name = lua_escape(layer_name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target = nil
     for i, layer in ipairs(spr.layers) do
@@ -140,17 +140,17 @@ async def set_layer_opacity(filename: str, layer_name: str, opacity: int) -> str
             break
         end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         target.opacity = {opacity}
     end)
 
     spr:saveAs(spr.filename)
-    return "Layer opacity set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Layer '{layer_name}' opacity set to {opacity} in {filename}"
     return f"Failed to set layer opacity: {output}"
@@ -229,15 +229,15 @@ async def duplicate_frame_range(filename: str, start_frame: int, end_frame: int,
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     local times = {times}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
-    if times < 1 then return "Times must be >= 1" end
+    if times < 1 then print("ERROR:Times must be >= 1") return end
 
     app.transaction(function()
         for t = 1, times do
@@ -258,10 +258,10 @@ async def duplicate_frame_range(filename: str, start_frame: int, end_frame: int,
     end)
 
     spr:saveAs(spr.filename)
-    return "Frame range duplicated"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Duplicated frames {start_frame}-{end_frame} (x{times}) in {filename}"
     return f"Failed to duplicate frame range: {output}"
@@ -296,7 +296,7 @@ async def set_cel_position(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -305,11 +305,11 @@ async def set_cel_position(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then
-        return "Frame index out of range"
+        print("ERROR:Frame index out of range") return
     end
 
     app.transaction(function()
@@ -337,10 +337,10 @@ async def set_cel_position(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel position set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Cel position set to ({x}, {y}) on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to set cel position: {output}"
@@ -381,7 +381,7 @@ async def tween_cel_positions(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -390,12 +390,12 @@ async def tween_cel_positions(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local span = end_idx - start_idx
@@ -430,10 +430,10 @@ async def tween_cel_positions(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel positions tweened"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Tweened cel positions on '{layer_name}' frames {start_frame}-{end_frame} in {filename}"
     return f"Failed to tween cel positions: {output}"
@@ -463,7 +463,7 @@ async def offset_cel_positions(
     safe_layer_name = lua_escape(layer_name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -472,12 +472,12 @@ async def offset_cel_positions(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     app.transaction(function()
@@ -492,10 +492,10 @@ async def offset_cel_positions(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel positions offset"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Offset cel positions by ({dx}, {dy}) on '{layer_name}' frames {start_frame}-{end_frame} in {filename}"
     return f"Failed to offset cel positions: {output}"
@@ -523,16 +523,16 @@ async def create_cel(
     safe_layer_name = lua_escape(layer_name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         local frame = spr.frames[idx]
@@ -543,10 +543,10 @@ async def create_cel(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel created"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Cel created on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to create cel: {output}"
@@ -560,16 +560,16 @@ async def clear_cel(filename: str, layer_name: str, frame_index: int) -> str:
     safe_layer_name = lua_escape(layer_name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         local frame = spr.frames[idx]
@@ -580,10 +580,10 @@ async def clear_cel(filename: str, layer_name: str, frame_index: int) -> str:
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel cleared"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Cel cleared on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to clear cel: {output}"
@@ -604,18 +604,18 @@ async def copy_cel(
     replace_flag = "true" if replace else "false"
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local src_idx = {source_frame}
     local dst_idx = {target_frame}
-    if src_idx < 1 or src_idx > #spr.frames then return "Source frame out of range" end
-    if dst_idx < 1 or dst_idx > #spr.frames then return "Target frame out of range" end
+    if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
+    if dst_idx < 1 or dst_idx > #spr.frames then print("ERROR:Target frame out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         local src = target:cel(spr.frames[src_idx])
@@ -632,10 +632,10 @@ async def copy_cel(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel copied"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Cel copied on '{layer_name}' from frame {source_frame} to {target_frame} in {filename}"
     return f"Failed to copy cel: {output}"
@@ -656,10 +656,10 @@ async def copy_frame(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local src_idx = {source_frame}
-    if src_idx < 1 or src_idx > #spr.frames then return "Source frame out of range" end
+    if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
 
     local dst_idx = {target_idx}
     app.transaction(function()
@@ -691,10 +691,10 @@ async def copy_frame(
     end)
 
     spr:saveAs(spr.filename)
-    return "Frame copied"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         if target_frame is None:
             return f"Frame {source_frame} copied to new frame in {filename}"
@@ -725,14 +725,14 @@ async def propagate_frame_to_range(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local src_idx = {source_frame}
     local start_idx = {start_frame}
     local end_idx = {end_frame}
-    if src_idx < 1 or src_idx > #spr.frames then return "Source frame out of range" end
+    if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     app.transaction(function()
@@ -761,10 +761,10 @@ async def propagate_frame_to_range(
     end)
 
     spr:saveAs(spr.filename)
-    return "Frame range propagated"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Propagated frame {source_frame} to frames {start_frame}-{end_frame} "
@@ -799,12 +799,12 @@ async def set_tag(
     safe_name = lua_escape(name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = {from_frame}
     local end_idx = {to_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local tag = nil
@@ -821,10 +821,10 @@ async def set_tag(
     tag.aniDir = {ani_dirs[direction]}
 
     spr:saveAs(spr.filename)
-    return "Tag set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Tag '{name}' set to frames {from_frame}-{to_frame} (direction={direction}) in {filename}"
     return f"Failed to set tag: {output}"
@@ -879,14 +879,14 @@ async def propagate_cels(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local src_idx = {source_frame}
     local start_idx = {start_frame}
     local end_idx = {end_frame}
-    if src_idx < 1 or src_idx > #spr.frames then return "Source frame out of range" end
+    if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local name_list = {layers_lua}
@@ -899,7 +899,7 @@ async def propagate_cels(
             end
         end
     end
-    if #targets == 0 then return "No layers found" end
+    if #targets == 0 then print("ERROR:No layers found") return end
 
     app.transaction(function()
         for fi = start_idx, end_idx do
@@ -924,10 +924,10 @@ async def propagate_cels(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cels propagated"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Propagated cels from frame {source_frame} to frames {start_frame}-{end_frame} "
@@ -963,7 +963,7 @@ async def tween_cel_positions_eased(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -972,12 +972,12 @@ async def tween_cel_positions_eased(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local function ease(t)
@@ -1026,10 +1026,10 @@ async def tween_cel_positions_eased(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel positions tweened with easing"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Tweened cel positions ({easing}) on '{layer_name}' frames {start_frame}-{end_frame} "
@@ -1060,7 +1060,7 @@ async def oscillate_cel_positions(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -1069,12 +1069,12 @@ async def oscillate_cel_positions(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local amplitude_x = {amplitude_x}
@@ -1117,10 +1117,10 @@ async def oscillate_cel_positions(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel positions oscillated"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Oscillated cel positions on '{layer_name}' frames {start_frame}-{end_frame} "
@@ -1156,7 +1156,7 @@ async def tween_cel_opacity_eased(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -1165,12 +1165,12 @@ async def tween_cel_opacity_eased(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local function ease(t)
@@ -1220,10 +1220,10 @@ async def tween_cel_opacity_eased(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel opacity tweened with easing"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Tweened cel opacity ({easing}) on '{layer_name}' frames {start_frame}-{end_frame} "
@@ -1266,7 +1266,7 @@ async def tween_cel_scale_eased(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target_layer = nil
     for _, layer in ipairs(spr.layers) do
@@ -1275,12 +1275,12 @@ async def tween_cel_scale_eased(
             break
         end
     end
-    if not target_layer then return "Layer not found" end
+    if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local source_frame = {source_idx}
@@ -1288,12 +1288,12 @@ async def tween_cel_scale_eased(
         source_frame = start_idx
     end
     if source_frame < 1 or source_frame > #spr.frames then
-        return "Source frame out of range"
+        print("ERROR:Source frame out of range") return
     end
 
     local source_cel = target_layer:cel(spr.frames[source_frame])
     if not source_cel then
-        return "Source cel not found"
+        print("ERROR:Source cel not found") return
     end
 
     local base_img = source_cel.image:clone()
@@ -1349,10 +1349,10 @@ async def tween_cel_scale_eased(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cel scale tweened with easing"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Tweened cel scale ({easing}) on '{layer_name}' frames {start_frame}-{end_frame} "

--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -168,7 +168,7 @@ async def get_sprite_info(filename: str) -> str:
     # NOTE: batch mode discards Lua `return` values — output MUST go through print().
     script = """
     local spr = app.activeSprite
-    if not spr then print("No active sprite") return end
+    if not spr then print("ERROR:No active sprite") return end
 
     local cm = "unknown"
     if spr.colorMode == ColorMode.RGB then cm = "rgb"
@@ -207,7 +207,7 @@ async def get_sprite_info(filename: str) -> str:
     print(table.concat(parts))
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return output
     return f"Failed to get sprite info: {output}"

--- a/aseprite_mcp/tools/canvas.py
+++ b/aseprite_mcp/tools/canvas.py
@@ -21,11 +21,11 @@ async def create_canvas(width: int, height: int, filename: str = "canvas.aseprit
     script = f"""
     local spr = Sprite({width}, {height})
     spr:saveAs("{safe_path}")
-    return "Canvas created successfully"
+    print("OK")
     """
-    
-    success, output = AsepriteCommand.execute_lua_script(script)
-    
+
+    success, output = AsepriteCommand.execute_lua_script_checked(script)
+
     if success:
         return f"Canvas created successfully: {filename}"
     else:
@@ -45,19 +45,19 @@ async def add_layer(filename: str, layer_name: str) -> str:
     safe_layer_name = lua_escape(layer_name)
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         spr:newLayer()
         app.activeLayer.name = "{safe_layer_name}"
     end)
-    
+
     spr:saveAs(spr.filename)
-    return "Layer added successfully"
+    print("OK")
     """
-    
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
-    
+
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+
     if success:
         return f"Layer '{layer_name}' added successfully to {filename}"
     else:
@@ -75,18 +75,18 @@ async def add_frame(filename: str) -> str:
     
     script = """
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
-    
+    if not spr then print("ERROR:No active sprite") return end
+
     app.transaction(function()
         spr:newFrame()
     end)
-    
+
     spr:saveAs(spr.filename)
-    return "Frame added successfully"
+    print("OK")
     """
-    
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
-    
+
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+
     if success:
         return f"New frame added successfully to {filename}"
     else:
@@ -105,11 +105,11 @@ async def set_frame(filename: str, frame_index: int) -> str:
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then
-        return "Frame index out of range"
+        print("ERROR:Frame index out of range") return
     end
 
     app.transaction(function()
@@ -117,10 +117,10 @@ async def set_frame(filename: str, frame_index: int) -> str:
     end)
 
     spr:saveAs(spr.filename)
-    return "Active frame set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Active frame set to {frame_index} in {filename}"
@@ -143,11 +143,11 @@ async def set_frame_duration(filename: str, frame_index: int, duration_ms: int) 
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then
-        return "Frame index out of range"
+        print("ERROR:Frame index out of range") return
     end
 
     app.transaction(function()
@@ -155,10 +155,10 @@ async def set_frame_duration(filename: str, frame_index: int, duration_ms: int) 
     end)
 
     spr:saveAs(spr.filename)
-    return "Frame duration set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Frame {frame_index} duration set to {duration_ms}ms in {filename}"
@@ -182,7 +182,7 @@ async def set_layer(filename: str, layer_name: str, create_if_missing: bool = Fa
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local target = nil
     for i, layer in ipairs(spr.layers) do
@@ -205,10 +205,10 @@ async def set_layer(filename: str, layer_name: str, create_if_missing: bool = Fa
     end)
 
     spr:saveAs(spr.filename)
-    return "Active layer set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Active layer set to '{layer_name}' in {filename}"

--- a/aseprite_mcp/tools/drawing.py
+++ b/aseprite_mcp/tools/drawing.py
@@ -34,7 +34,7 @@ async def draw_pixels(filename: str, pixels: List[Dict[str, Any]]) -> str:
 
     script = """
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         local cel = app.activeCel
@@ -44,7 +44,7 @@ async def draw_pixels(filename: str, pixels: List[Dict[str, Any]]) -> str:
             app.activeFrame = spr.frames[1]
             cel = app.activeCel
             if not cel then
-                return "No active cel and couldn't create one"
+                print("ERROR:No active cel and couldn't create one") return
             end
         end
 
@@ -72,10 +72,10 @@ async def draw_pixels(filename: str, pixels: List[Dict[str, Any]]) -> str:
     end)
 
     spr:saveAs(spr.filename)
-    return "Pixels drawn successfully"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Pixels drawn successfully in {filename}"
@@ -105,7 +105,7 @@ async def draw_line(filename: str, x1: int, y1: int, x2: int, y2: int, color: st
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local function put_thick(img, x, y, color, size)
         local r = math.max(0, math.floor(size / 2))
@@ -142,7 +142,7 @@ async def draw_line(filename: str, x1: int, y1: int, x2: int, y2: int, color: st
             app.activeFrame = spr.frames[1]
             cel = app.activeCel
             if not cel then
-                return "No active cel and couldn't create one"
+                print("ERROR:No active cel and couldn't create one") return
             end
         end
         local img = cel.image
@@ -156,10 +156,10 @@ async def draw_line(filename: str, x1: int, y1: int, x2: int, y2: int, color: st
     end)
 
     spr:saveAs(spr.filename)
-    return "Line drawn successfully"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Line drawn successfully in {filename}"
@@ -196,7 +196,7 @@ async def draw_rectangle(filename: str, x: int, y: int, width: int, height: int,
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         local cel = app.activeCel
@@ -205,7 +205,7 @@ async def draw_rectangle(filename: str, x: int, y: int, width: int, height: int,
             app.activeFrame = spr.frames[1]
             cel = app.activeCel
             if not cel then
-                return "No active cel and couldn't create one"
+                print("ERROR:No active cel and couldn't create one") return
             end
         end
 
@@ -219,10 +219,10 @@ async def draw_rectangle(filename: str, x: int, y: int, width: int, height: int,
     end)
 
     spr:saveAs(spr.filename)
-    return "Rectangle drawn successfully"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Rectangle drawn successfully in {filename}"
@@ -249,7 +249,7 @@ async def fill_area(filename: str, x: int, y: int, color: str = "#000000") -> st
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         local cel = app.activeCel
@@ -258,7 +258,7 @@ async def fill_area(filename: str, x: int, y: int, color: str = "#000000") -> st
             app.activeFrame = spr.frames[1]
             cel = app.activeCel
             if not cel then
-                return "No active cel and couldn't create one"
+                print("ERROR:No active cel and couldn't create one") return
             end
         end
 
@@ -271,10 +271,10 @@ async def fill_area(filename: str, x: int, y: int, color: str = "#000000") -> st
     end)
 
     spr:saveAs(spr.filename)
-    return "Area filled successfully"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Area filled successfully in {filename}"
@@ -303,7 +303,7 @@ async def draw_circle(filename: str, center_x: int, center_y: int, radius: int, 
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         local cel = app.activeCel
@@ -312,7 +312,7 @@ async def draw_circle(filename: str, center_x: int, center_y: int, radius: int, 
             app.activeFrame = spr.frames[1]
             cel = app.activeCel
             if not cel then
-                return "No active cel and couldn't create one"
+                print("ERROR:No active cel and couldn't create one") return
             end
         end
 
@@ -329,10 +329,10 @@ async def draw_circle(filename: str, center_x: int, center_y: int, radius: int, 
     end)
 
     spr:saveAs(spr.filename)
-    return "Circle drawn successfully"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
         return f"Circle drawn successfully in {filename}"
@@ -363,16 +363,16 @@ async def draw_pixels_at(
     create_flag = "true" if create_if_missing else "false"
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -402,10 +402,10 @@ async def draw_pixels_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Pixels drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Pixels drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw pixels: {output}"
@@ -436,7 +436,7 @@ async def draw_line_at(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local function put_thick(img, x, y, color, size)
         local r = math.max(0, math.floor(size / 2))
@@ -467,13 +467,13 @@ async def draw_line_at(
     end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -492,10 +492,10 @@ async def draw_line_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Line drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Line drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw line: {output}"
@@ -530,16 +530,16 @@ async def draw_rectangle_at(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -560,10 +560,10 @@ async def draw_rectangle_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Rectangle drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Rectangle drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw rectangle: {output}"
@@ -593,16 +593,16 @@ async def draw_circle_at(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -626,10 +626,10 @@ async def draw_circle_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Circle drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Circle drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw circle: {output}"
@@ -657,16 +657,16 @@ async def fill_area_at(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -686,10 +686,10 @@ async def fill_area_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Area filled"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Area filled on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to fill area: {output}"
@@ -721,7 +721,7 @@ async def draw_polygon(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local function put_thick(img, x, y, color, size)
         local r = math.max(0, math.floor(size / 2))
@@ -780,13 +780,13 @@ async def draw_polygon(
     end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -819,10 +819,10 @@ async def draw_polygon(
     end)
 
     spr:saveAs(spr.filename)
-    return "Polygon drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Polygon drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw polygon: {output}"
@@ -853,7 +853,7 @@ async def draw_path(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local function put_thick(img, x, y, color, size)
         local r = math.max(0, math.floor(size / 2))
@@ -884,13 +884,13 @@ async def draw_path(
     end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -916,10 +916,10 @@ async def draw_path(
     end)
 
     spr:saveAs(spr.filename)
-    return "Path drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Path drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw path: {output}"
@@ -959,16 +959,16 @@ async def apply_gradient_rect(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -1001,10 +1001,10 @@ async def apply_gradient_rect(
     end)
 
     spr:saveAs(spr.filename)
-    return "Gradient applied"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Gradient applied on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to apply gradient: {output}"
@@ -1051,16 +1051,16 @@ async def draw_ellipse_at(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
         app.activeLayer = target
@@ -1084,10 +1084,10 @@ async def draw_ellipse_at(
     end)
 
     spr:saveAs(spr.filename)
-    return "Ellipse drawn"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Ellipse drawn on '{layer_name}' frame {frame_index} in {filename}"
     return f"Failed to draw ellipse: {output}"

--- a/aseprite_mcp/tools/export.py
+++ b/aseprite_mcp/tools/export.py
@@ -31,7 +31,18 @@ async def export_sprite(filename: str, output_filename: str, format: str = "png"
         # For still image exports
         args = ["--batch", filename, "--save-as", output_filename]
         success, output = AsepriteCommand.run_command(args)
-    
+
+    # Aseprite exits 0 even when it cannot write the requested format
+    # (e.g. format="json"). Confirm a file actually appeared. A multi-frame
+    # sprite saved to a still format produces frame-numbered siblings
+    # (out1.png, out2.png, ...) instead of the exact name, so accept those
+    # too — same convention as export_frame.
+    if success:
+        base, ext = os.path.splitext(output_filename)
+        if not os.path.exists(output_filename) and not glob.glob(f"{base}*{ext}"):
+            success = False
+            output = "Aseprite exited 0 but wrote no file (the format may not be writable via --save-as)"
+
     if success:
         return f"Sprite exported successfully to {output_filename}"
     else:
@@ -62,13 +73,16 @@ async def copy_sprite(filename: str, output_filename: str, overwrite: bool = Fal
     safe_path = lua_escape(output_filename.replace("\\", "/"))
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     spr:saveAs("{safe_path}")
-    return "Sprite copied"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success and not os.path.exists(output_filename):
+        success = False
+        output = "Aseprite exited 0 but wrote no file"
     if success:
         return f"Sprite copied to {output_filename}"
     return f"Failed to copy sprite: {output}"

--- a/aseprite_mcp/tools/export.py
+++ b/aseprite_mcp/tools/export.py
@@ -215,6 +215,12 @@ async def export_spritesheet(
     args += ["--sheet", output_filename]
 
     success, output = AsepriteCommand.run_command(args)
+    if success and not os.path.exists(output_filename):
+        success = False
+        output = "Aseprite exited 0 but wrote no sheet file"
+    if success and data_filename and not os.path.exists(data_filename):
+        success = False
+        output = "Aseprite exited 0 but wrote no data file"
     if success:
         msg = f"Sprite sheet exported to {output_filename} ({sheet_type})"
         if data_filename:
@@ -251,12 +257,14 @@ async def export_layers(
         "--save-as", os.path.join(output_directory, "{layer}.png"),
     ]
     success, output = AsepriteCommand.run_command(args)
-    if success:
-        produced = sorted(
-            os.path.basename(p) for p in glob.glob(os.path.join(output_directory, "*.png"))
-        )
-        return f"Layers exported to {output_directory}: {', '.join(produced) or '(none)'}"
-    return f"Failed to export layers: {output}"
+    if not success:
+        return f"Failed to export layers: {output}"
+    produced = sorted(
+        os.path.basename(p) for p in glob.glob(os.path.join(output_directory, "*.png"))
+    )
+    if not produced:
+        return "Failed to export layers: Aseprite exited 0 but wrote no PNG files"
+    return f"Layers exported to {output_directory}: {', '.join(produced)}"
 
 
 @mcp.tool()
@@ -282,11 +290,35 @@ async def export_tag(
     if err:
         return err
 
+    # --tag silently exports *all* frames (exit 0) when the tag does not
+    # exist, so a produced file is not proof the tag was honoured. Validate
+    # the tag up front — same approach as export_spritesheet.
+    safe_tag = lua_escape(tag_name)
+    check = f"""
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+    for _, tag in ipairs(spr.tags) do
+        if tag.name == "{safe_tag}" then print("OK") return end
+    end
+    print("ERROR:Tag not found")
+    """
+    ok, out = AsepriteCommand.execute_lua_script_checked(check, filename)
+    if not ok:
+        return f"Failed to export tag: {out}"
+
     args = ["--batch", filename, "--tag", tag_name]
     if scale > 1:
         args += ["--scale", str(scale)]
     args += ["--save-as", output_filename]
     success, output = AsepriteCommand.run_command(args)
+    if success:
+        # A multi-frame tag saved to a still format produces frame-numbered
+        # siblings instead of the exact name — accept those, same convention
+        # as export_sprite/export_frame.
+        base, ext = os.path.splitext(output_filename)
+        if not os.path.exists(output_filename) and not glob.glob(f"{base}*{ext}"):
+            success = False
+            output = "Aseprite exited 0 but wrote no file"
     if success:
         return f"Tag '{tag_name}' exported to {output_filename}"
     return f"Failed to export tag: {output}"

--- a/aseprite_mcp/tools/palette.py
+++ b/aseprite_mcp/tools/palette.py
@@ -110,16 +110,16 @@ async def set_palette(filename: str, colors: List[str]) -> str:
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local pal = Palette({len(rgb_list)})
 {palette_entries}
     spr:setPalette(pal)
     spr:saveAs(spr.filename)
-    return "Palette set"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Palette set with {len(colors)} colors in {filename}"
     return f"Failed to set palette: {output}"
@@ -159,26 +159,26 @@ async def remap_colors_in_cel_range(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame}
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer_name}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     local source_frame = {source_idx}
     if source_frame == nil then
         source_frame = start_idx
     end
     if source_frame < 1 or source_frame > #spr.frames then
-        return "Source frame out of range"
+        print("ERROR:Source frame out of range") return
     end
 
     local map = {{ {mapping_lua} }}
@@ -222,10 +222,10 @@ async def remap_colors_in_cel_range(
     end)
 
     spr:saveAs(spr.filename)
-    return "Colors remapped"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Remapped colors on '{layer_name}' frames {start_frame}-{end_frame} in {filename}"

--- a/aseprite_mcp/tools/palette.py
+++ b/aseprite_mcp/tools/palette.py
@@ -64,10 +64,10 @@ async def get_palette(filename: str) -> str:
 
     script = """
     local spr = app.activeSprite
-    if not spr then print("No active sprite") return end
+    if not spr then print("ERROR:No active sprite") return end
 
     local ok, pal = pcall(function() return spr.palettes[1] end)
-    if not ok or not pal then print("No palette") return end
+    if not ok or not pal then print("ERROR:No palette") return end
 
     local parts = {}
     local size = #pal
@@ -84,7 +84,7 @@ async def get_palette(filename: str) -> str:
     print(table.concat(parts))
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return output
     return f"Failed to get palette: {output}"

--- a/aseprite_mcp/tools/pixel_read.py
+++ b/aseprite_mcp/tools/pixel_read.py
@@ -68,7 +68,7 @@ async def get_pixel_color(
 
     for line in output.splitlines():
         if line.startswith("ERROR:"):
-            return line[6:]
+            return f"Failed to read pixel: {line[6:]}"
         if line.startswith("PIXEL:"):
             parts = line[6:].split(",")
             r, g, b, a = int(parts[0]), int(parts[1]), int(parts[2]), int(parts[3])
@@ -162,7 +162,7 @@ async def get_pixels_rect(
     pixels = []
     for line in output.splitlines():
         if line.startswith("ERROR:"):
-            return line[6:]
+            return f"Failed to read pixels: {line[6:]}"
         if line.startswith("PIXEL:"):
             parts = line[6:].split(",")
             px, py, r, g, b, a = [int(p) for p in parts]

--- a/aseprite_mcp/tools/quality.py
+++ b/aseprite_mcp/tools/quality.py
@@ -71,13 +71,13 @@ async def ensure_layers_present(
 
     script = """
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = __START__
     local end_idx = __END__
     if end_idx == nil then end_idx = #spr.frames end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local names = __LAYERS__
@@ -90,7 +90,7 @@ async def ensure_layers_present(
             end
         end
     end
-    if #targets == 0 then return "No layers found" end
+    if #targets == 0 then print("ERROR:No layers found") return end
 
     app.transaction(function()
         for fi = start_idx, end_idx do
@@ -106,7 +106,7 @@ async def ensure_layers_present(
     end)
 
     spr:saveAs(spr.filename)
-    return "Cels ensured"
+    print("OK")
     """
 
     script = (
@@ -116,7 +116,7 @@ async def ensure_layers_present(
         .replace("__LAYERS__", layers_lua)
     )
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return (
             f"Ensured cels for layers {', '.join(layer_names)} "
@@ -145,13 +145,13 @@ async def validate_scene(
 
     script = """
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = __START__
     local end_idx = __END__
     if end_idx == nil then end_idx = #spr.frames end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local names = __LAYERS__
@@ -205,7 +205,7 @@ async def validate_scene(
         .replace("__LAYERS__", layers_lua)
     )
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return output
     return f"Failed to validate scene: {output}"
@@ -251,13 +251,13 @@ async def audit_animation(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame_val}
     if end_idx == nil then end_idx = #spr.frames end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local target_names = {layers_lua}
@@ -441,7 +441,7 @@ async def audit_animation(
     print(table.concat(parts))
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return output
     return f"Failed to audit animation: {output}"
@@ -507,13 +507,13 @@ async def animation_sanitize(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local start_idx = {start_frame}
     local end_idx = {end_frame_val}
     if end_idx == nil then end_idx = #spr.frames end
     if start_idx < 1 or end_idx > #spr.frames or start_idx > end_idx then
-        return "Frame range out of bounds"
+        print("ERROR:Frame range out of bounds") return
     end
 
     local target_names = {layers_lua}
@@ -855,7 +855,7 @@ async def animation_sanitize(
     return output
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return output
     return f"Failed to sanitize animation: {output}"

--- a/aseprite_mcp/tools/scene.py
+++ b/aseprite_mcp/tools/scene.py
@@ -38,9 +38,9 @@ async def copy_layers_between_sprites(
 
     script = f"""
     local src = app.open("{src_path}")
-    if not src then return "Source sprite not opened" end
+    if not src then print("ERROR:Source sprite not opened") return end
     local dst = app.open("{dst_path}")
-    if not dst then return "Target sprite not opened" end
+    if not dst then print("ERROR:Target sprite not opened") return end
 
     local function find_layer(spr, name)
         for _, layer in ipairs(spr.layers) do
@@ -51,6 +51,17 @@ async def copy_layers_between_sprites(
 
     local names = {layers_lua}
     local missing = {{}}
+    local valid = {{}}
+    for _, name in ipairs(names) do
+        if find_layer(src, name) then
+            table.insert(valid, name)
+        else
+            table.insert(missing, name)
+        end
+    end
+    if #valid == 0 then
+        print("ERROR:None of the requested layers exist in the source: " .. table.concat(missing, ", ")) return
+    end
 
     app.transaction(function()
         if {create_frames_flag} then
@@ -59,35 +70,31 @@ async def copy_layers_between_sprites(
             end
         end
 
-        for _, name in ipairs(names) do
+        for _, name in ipairs(valid) do
             local src_layer = find_layer(src, name)
-            if not src_layer then
-                table.insert(missing, name)
-            else
-                local dst_layer = find_layer(dst, name)
-                if not dst_layer then
-                    dst_layer = dst:newLayer()
-                    dst_layer.name = name
+            local dst_layer = find_layer(dst, name)
+            if not dst_layer then
+                dst_layer = dst:newLayer()
+                dst_layer.name = name
+            end
+            if {replace_flag} then
+                for i = 1, #dst.frames do
+                    local cel = dst_layer:cel(dst.frames[i])
+                    if cel then dst:deleteCel(cel) end
                 end
-                if {replace_flag} then
-                    for i = 1, #dst.frames do
-                        local cel = dst_layer:cel(dst.frames[i])
-                        if cel then dst:deleteCel(cel) end
-                    end
-                end
-                for i = 1, #src.frames do
-                    if i <= #dst.frames then
-                        local src_cel = src_layer:cel(src.frames[i])
-                        if src_cel then
-                            local dst_cel = dst_layer:cel(dst.frames[i])
-                            if dst_cel and {replace_flag} then
-                                dst:deleteCel(dst_cel)
-                                dst_cel = nil
-                            end
-                            if not dst_cel then
-                                local img = src_cel.image:clone()
-                                dst:newCel(dst_layer, dst.frames[i], img, src_cel.position)
-                            end
+            end
+            for i = 1, #src.frames do
+                if i <= #dst.frames then
+                    local src_cel = src_layer:cel(src.frames[i])
+                    if src_cel then
+                        local dst_cel = dst_layer:cel(dst.frames[i])
+                        if dst_cel and {replace_flag} then
+                            dst:deleteCel(dst_cel)
+                            dst_cel = nil
+                        end
+                        if not dst_cel then
+                            local img = src_cel.image:clone()
+                            dst:newCel(dst_layer, dst.frames[i], img, src_cel.position)
                         end
                     end
                 end
@@ -97,12 +104,19 @@ async def copy_layers_between_sprites(
 
     dst:saveAs(dst.filename)
     if #missing > 0 then
-        return "Copied layers with missing: " .. table.concat(missing, ", ")
+        print("MISSING:" .. table.concat(missing, ", "))
     end
-    return "Layers copied"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script)
-    if success:
-        return f"Layers copied from {source_filename} to {target_filename}"
-    return f"Failed to copy layers: {output}"
+    success, output = AsepriteCommand.execute_lua_script_checked(script)
+    if not success:
+        return f"Failed to copy layers: {output}"
+    missing = next(
+        (line[len("MISSING:"):] for line in output.splitlines() if line.startswith("MISSING:")),
+        None,
+    )
+    msg = f"Layers copied from {source_filename} to {target_filename}"
+    if missing:
+        msg += f" (skipped missing layers: {missing})"
+    return msg

--- a/aseprite_mcp/tools/transform.py
+++ b/aseprite_mcp/tools/transform.py
@@ -28,19 +28,19 @@ async def flip_layer(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])
-    if not cel then return "No cel at that layer/frame" end
+    if not cel then print("ERROR:No cel at that layer/frame") return end
 
     app.transaction(function()
         local img = cel.image
@@ -68,10 +68,10 @@ async def flip_layer(
     end)
 
     spr:saveAs(spr.filename)
-    return "Layer flipped"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Layer '{layer_name}' flipped {direction}ly in {filename}"
     return f"Failed to flip layer: {output}"
@@ -145,19 +145,19 @@ async def rotate_layer(
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     local idx = {frame_index}
-    if idx < 1 or idx > #spr.frames then return "Frame index out of range" end
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
     local target = nil
     for _, layer in ipairs(spr.layers) do
         if layer.name == "{safe_layer}" then target = layer break end
     end
-    if not target then return "Layer not found" end
+    if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])
-    if not cel then return "No cel at that layer/frame" end
+    if not cel then print("ERROR:No cel at that layer/frame") return end
 
     app.transaction(function()
         local img = cel.image
@@ -165,10 +165,10 @@ async def rotate_layer(
     end)
 
     spr:saveAs(spr.filename)
-    return "Layer rotated"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Layer '{layer_name}' rotated {angle}° clockwise in {filename}"
     return f"Failed to rotate layer: {output}"
@@ -190,17 +190,17 @@ async def resize_canvas(filename: str, width: int, height: int) -> str:
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
 
     app.transaction(function()
         spr:resize({width}, {height})
     end)
 
     spr:saveAs(spr.filename)
-    return "Canvas resized"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Canvas resized to {width}x{height} in {filename}"
     return f"Failed to resize canvas: {output}"
@@ -224,17 +224,21 @@ async def crop_canvas(filename: str, x: int, y: int, width: int, height: int) ->
 
     script = f"""
     local spr = app.activeSprite
-    if not spr then return "No active sprite" end
+    if not spr then print("ERROR:No active sprite") return end
+
+    if {x} >= spr.width or {y} >= spr.height or {x} + {width} <= 0 or {y} + {height} <= 0 then
+        print("ERROR:Crop rect is fully outside the canvas") return
+    end
 
     app.transaction(function()
         spr:crop({x}, {y}, {width}, {height})
     end)
 
     spr:saveAs(spr.filename)
-    return "Canvas cropped"
+    print("OK")
     """
 
-    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
         return f"Canvas cropped to ({x},{y}) {width}x{height} in {filename}"
     return f"Failed to crop canvas: {output}"

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -1,0 +1,84 @@
+"""Regression tests for issue #15: Lua-side errors must reach the caller.
+
+Before the fix, `aseprite --batch --script` discarded the script's Lua
+`return` value and always exited 0, so mutating tools fabricated a success
+message from their input args even when the script did nothing. Every call
+below feeds invalid input and asserts the tool now reports failure instead
+of a fabricated success.
+"""
+from conftest import ok, run
+
+from aseprite_mcp.tools import (
+    animation,
+    canvas,
+    drawing,
+    export,
+    palette,
+    quality,
+    scene,
+    transform,
+)
+
+
+def failed(result):
+    """Assert a tool surfaced a failure rather than a fabricated success."""
+    assert str(result).startswith(("Failed", "ERROR")), result
+    return result
+
+
+# --- issue #15 reproduction table: each must now fail loudly ---
+
+def test_set_layer_visibility_missing_layer(sprite):
+    failed(run(animation.set_layer_visibility(sprite, "NOT_A_LAYER", False)))
+
+
+def test_set_frame_duration_out_of_range(sprite):
+    failed(run(canvas.set_frame_duration(sprite, 99, 50)))
+
+
+def test_set_tag_range_out_of_bounds(sprite):
+    failed(run(animation.set_tag(sprite, "bad_tag", 5, 99)))
+
+
+def test_remap_colors_missing_layer(sprite):
+    failed(run(palette.remap_colors_in_cel_range(
+        sprite, "NOSUCHLAYER", 1, 1, [{"from": "#D04648", "to": "#000000"}])))
+
+
+def test_ensure_layers_present_all_missing(sprite):
+    failed(run(quality.ensure_layers_present(sprite, ["MISSING"])))
+
+
+def test_export_sprite_unwritable_format(sprite):
+    # Aseprite exits 0 but writes nothing for format="json".
+    failed(run(export.export_sprite(sprite, "/tmp/ase-pytest/err_out", "json")))
+
+
+# --- copy_layers_between_sprites: all-missing fails; partial surfaces skips ---
+
+def test_copy_layers_all_missing_fails(sprite, base_dir):
+    target = f"{base_dir}/copy_target.aseprite"
+    ok(run(canvas.create_canvas(16, 16, target)))
+    failed(run(scene.copy_layers_between_sprites(sprite, target, ["BOGUS"])))
+
+
+def test_copy_layers_partial_surfaces_skipped(sprite, base_dir):
+    target = f"{base_dir}/copy_target2.aseprite"
+    ok(run(canvas.create_canvas(16, 16, target)))
+    result = run(scene.copy_layers_between_sprites(sprite, target, ["body", "BOGUS"]))
+    ok(result)
+    assert "skipped missing layers" in result and "BOGUS" in result, result
+
+
+# --- new guards added alongside the conversion ---
+
+def test_crop_fully_outside_canvas_rejected(sprite):
+    failed(run(transform.crop_canvas(sprite, 999, 999, 10, 10)))
+
+
+def test_flip_missing_layer(sprite):
+    failed(run(transform.flip_layer(sprite, "NO_SUCH_LAYER", 1)))
+
+
+def test_draw_line_missing_layer(sprite):
+    failed(run(drawing.draw_line_at(sprite, "NO_SUCH_LAYER", 1, 0, 0, 5, 5, "#ffffff", 1)))

--- a/tests/test_error_propagation.py
+++ b/tests/test_error_propagation.py
@@ -14,6 +14,7 @@ from aseprite_mcp.tools import (
     drawing,
     export,
     palette,
+    pixel_read,
     quality,
     scene,
     transform,
@@ -52,6 +53,27 @@ def test_ensure_layers_present_all_missing(sprite):
 def test_export_sprite_unwritable_format(sprite):
     # Aseprite exits 0 but writes nothing for format="json".
     failed(run(export.export_sprite(sprite, "/tmp/ase-pytest/err_out", "json")))
+
+
+def test_export_tag_missing_tag(sprite):
+    # --tag silently exports *all* frames (exit 0) for an unknown tag, so the
+    # tool must validate the tag rather than report a fabricated tag export.
+    failed(run(export.export_tag(sprite, "NO_SUCH_TAG", "/tmp/ase-pytest/err_tag.gif")))
+
+
+def test_export_spritesheet_missing_tag(sprite):
+    failed(run(export.export_spritesheet(
+        sprite, "/tmp/ase-pytest/err_sheet.png", "horizontal", "", 1, 0, "NO_SUCH_TAG")))
+
+
+# --- readers surfaced a hard error as data (read as success); now fail loudly ---
+
+def test_get_pixel_color_missing_layer(sprite):
+    failed(run(pixel_read.get_pixel_color(sprite, 0, 0, "NO_SUCH_LAYER")))
+
+
+def test_get_pixels_rect_missing_layer(sprite):
+    failed(run(pixel_read.get_pixels_rect(sprite, 0, 0, 4, 4, "NO_SUCH_LAYER")))
 
 
 # --- copy_layers_between_sprites: all-missing fails; partial surfaces skips ---


### PR DESCRIPTION
Fixes #15.

## The bug

`aseprite --batch --script foo.lua` **discards the script's Lua `return` value and always exits with code 0.** Many mutating tools signalled failure by returning a message from Lua:

```lua
local target = find_layer(spr, name)
if not target then return "Layer not found" end
```

That string never reaches Python, and because the process still exits 0, the Python side treated the call as a success and built a confirmation message out of the **input arguments**:

```python
success, output = AsepriteCommand.execute_lua_script(script, filename)
if success:
    return f"Layer '{layer_name}' visibility set to {visible}"   # printed even when the layer did not exist
```

So every invalid call — missing layer, out-of-range frame, bad tag range, unwritable export format — came back looking like it worked. For an LLM client this is the worst case: the model's view of the file silently drifts from what is on disk.

## The fix

The repo already has the right primitive: `execute_lua_script_checked`, which scans stdout for a line beginning `ERROR:` and reports failure when it finds one. This PR makes every mutating tool use it.

1. Lua error guards now **print** a sentinel instead of returning a discarded string:

   ```lua
   if not target then print("ERROR:Layer not found") return end
   ```

2. The happy path prints `OK`, and the call routes through `execute_lua_script_checked`, so the templated success message is returned **only** when the script actually did the work.

Applied to every remaining unchecked mutating tool in `canvas`, `drawing`, `transform`, `scene`, `palette`, `animation`, and `quality`. The `layers`, `slices`, `selection`, `fx`, `tilemap`, and `analysis` modules already used this helper, so after this PR the convention is uniform across the codebase.

## Also fixed (same false-success class)

- **`export_sprite`** — Aseprite exits 0 even when it cannot write the requested format (e.g. `format="json"`). Now confirms a file actually appeared before reporting success; frame-numbered siblings (`out1.png`) are accepted, matching `export_frame`.
- **`crop_canvas`** — a crop rect fully outside the canvas silently blanked the whole sprite while reporting success. Now rejected with an error.
- **`copy_layers_between_sprites`** — now fails when none of the requested layers exist, and surfaces the skipped names on a partial copy.

## Deliberately left alone

- **Reporters** (`validate_scene`, `audit_animation`, `animation_sanitize`) keep printing their JSON output; only their hard-failure guards were converted.
- **Readers** (`get_*`) and **`run_lua_script`** stay on the unchecked helper — they return data or arbitrary user output, not a templated success string.
- **Recursive group-layer lookup** (the grouped-layer silent no-op noted in #15) is a behaviour change of its own and is left for a separate PR.

## Tests

New `tests/test_error_propagation.py` feeds invalid input to each tool from the issue's reproduction table and asserts a loud failure, plus the partial-copy and new-guard cases. Full suite green against Aseprite 1.3.17.2 (Linux, headless):

```
64 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)