### PR TITLE
feat(layers): resolve layer names inside groups (#17)

### DIFF
--- a/aseprite_mcp/core/lua.py
+++ b/aseprite_mcp/core/lua.py
@@ -5,14 +5,52 @@ with them should print "ERROR:<message>" to signal failure and be run
 through AsepriteCommand.execute_lua_script_checked.
 """
 
-# Find a top-level layer by name (same convention as the rest of the
-# codebase: groups are not traversed).
+# Resolve a layer by name, searching inside groups.
+#
+#   1. An exact full-name match (including any "/") is tried first, breadth-
+#      first, so a shallower layer wins over a deeper namesake and a layer or
+#      group whose own name contains "/" is reachable directly.
+#   2. Otherwise the name is read as a "group/child" path. Aseprite allows "/"
+#      inside names, so segments are matched longest-prefix-first with
+#      backtracking: "abc/x/y" resolves a group named "abc/x" then child "y",
+#      yet a genuine "abc" -> "x" -> "y" hierarchy still resolves because a
+#      dead-end longer prefix falls back to the shorter one. When two parses
+#      are both valid the longest leading group name wins.
+#
+# Used for *operation* lookups — duplicate-name guards must stay top-level,
+# since Aseprite permits the same name in different groups.
 FIND_LAYER = """
 local function find_layer(spr, name)
-    for _, layer in ipairs(spr.layers) do
+    local queue = {}
+    for _, layer in ipairs(spr.layers) do queue[#queue + 1] = layer end
+    local head = 1
+    while head <= #queue do
+        local layer = queue[head]
+        head = head + 1
         if layer.name == name then return layer end
+        if layer.isGroup then
+            for _, child in ipairs(layer.layers) do queue[#queue + 1] = child end
+        end
     end
-    return nil
+    if not string.find(name, "/", 1, true) then return nil end
+    local segs = {}
+    for segment in string.gmatch(name, "[^/]+") do segs[#segs + 1] = segment end
+    local function resolve(layers, i)
+        for j = #segs, i, -1 do
+            local cand = table.concat(segs, "/", i, j)
+            for _, layer in ipairs(layers) do
+                if layer.name == cand then
+                    if j == #segs then return layer end
+                    if layer.isGroup then
+                        local found = resolve(layer.layers, j + 1)
+                        if found then return found end
+                    end
+                end
+            end
+        end
+        return nil
+    end
+    return resolve(spr.layers, 1)
 end
 """
 

--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -1,6 +1,7 @@
 import os
 import json
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -92,13 +93,8 @@ async def set_layer_visibility(filename: str, layer_name: str, visible: bool = T
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -133,13 +129,8 @@ async def set_layer_opacity(filename: str, layer_name: str, opacity: int) -> str
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -298,13 +289,8 @@ async def set_cel_position(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local idx = {frame_index}
@@ -383,13 +369,8 @@ async def tween_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -465,13 +446,8 @@ async def offset_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -528,10 +504,8 @@ async def create_cel(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -565,10 +539,8 @@ async def clear_cel(filename: str, layer_name: str, frame_index: int) -> str:
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -611,10 +583,8 @@ async def copy_cel(
     if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
     if dst_idx < 1 or dst_idx > #spr.frames then print("ERROR:Target frame out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -889,15 +859,12 @@ async def propagate_cels(
         print("ERROR:Frame range out of bounds") return
     end
 
+    {FIND_LAYER}
     local name_list = {layers_lua}
     local targets = {{}}
     for _, name in ipairs(name_list) do
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == name then
-                table.insert(targets, layer)
-                break
-            end
-        end
+        local m = find_layer(spr, name)
+        if m then table.insert(targets, m) end
     end
     if #targets == 0 then print("ERROR:No layers found") return end
 
@@ -965,13 +932,8 @@ async def tween_cel_positions_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1062,13 +1024,8 @@ async def oscillate_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1158,13 +1115,8 @@ async def tween_cel_opacity_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1268,13 +1220,8 @@ async def tween_cel_scale_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1458,10 +1405,8 @@ async def set_cel_opacity(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])

--- a/aseprite_mcp/tools/canvas.py
+++ b/aseprite_mcp/tools/canvas.py
@@ -1,5 +1,6 @@
 import os
 from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -184,13 +185,8 @@ async def set_layer(filename: str, layer_name: str, create_if_missing: bool = Fa
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
 
     app.transaction(function()
         if not target then

--- a/aseprite_mcp/tools/drawing.py
+++ b/aseprite_mcp/tools/drawing.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Dict, Any
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -368,10 +369,8 @@ async def draw_pixels_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -469,10 +468,8 @@ async def draw_line_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -535,10 +532,8 @@ async def draw_rectangle_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -598,10 +593,8 @@ async def draw_circle_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -662,10 +655,8 @@ async def fill_area_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -782,10 +773,8 @@ async def draw_polygon(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -886,10 +875,8 @@ async def draw_path(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -964,10 +951,8 @@ async def apply_gradient_rect(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -1056,10 +1041,8 @@ async def draw_ellipse_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()

--- a/aseprite_mcp/tools/palette.py
+++ b/aseprite_mcp/tools/palette.py
@@ -167,10 +167,8 @@ async def remap_colors_in_cel_range(
         print("ERROR:Frame range out of bounds") return
     end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     local source_frame = {source_idx}

--- a/aseprite_mcp/tools/pixel_read.py
+++ b/aseprite_mcp/tools/pixel_read.py
@@ -1,6 +1,7 @@
 import json
 import os
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -34,10 +35,8 @@ async def get_pixel_color(
 
     local cel = nil
     if "{safe_layer}" ~= "" then
-        local target = nil
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == "{safe_layer}" then target = layer break end
-        end
+        {FIND_LAYER}
+        local target = find_layer(spr, "{safe_layer}")
         if not target then print("ERROR:Layer not found") return end
         cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end
@@ -119,10 +118,8 @@ async def get_pixels_rect(
 
     local cel = nil
     if "{safe_layer}" ~= "" then
-        local target = nil
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == "{safe_layer}" then target = layer break end
-        end
+        {FIND_LAYER}
+        local target = find_layer(spr, "{safe_layer}")
         if not target then print("ERROR:Layer not found") return end
         cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end

--- a/aseprite_mcp/tools/scene.py
+++ b/aseprite_mcp/tools/scene.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -42,12 +43,7 @@ async def copy_layers_between_sprites(
     local dst = app.open("{dst_path}")
     if not dst then print("ERROR:Target sprite not opened") return end
 
-    local function find_layer(spr, name)
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == name then return layer end
-        end
-        return nil
-    end
+    {FIND_LAYER}
 
     local names = {layers_lua}
     local missing = {{}}

--- a/aseprite_mcp/tools/tilemap.py
+++ b/aseprite_mcp/tools/tilemap.py
@@ -51,7 +51,14 @@ async def create_tilemap_layer(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    if find_layer(spr, "{safe_layer}") then print("ERROR:Layer with that name already exists") return end
+    -- Duplicate-name guard is top-level only: the new layer is created at the
+    -- root, and Aseprite permits the same name inside a different group, so a
+    -- recursive find_layer would reject valid names.
+    local name_taken = false
+    for _, layer in ipairs(spr.layers) do
+        if layer.name == "{safe_layer}" then name_taken = true break end
+    end
+    if name_taken then print("ERROR:Layer with that name already exists") return end
 
     app.transaction(function()
         spr.gridBounds = Rectangle(0, 0, {tile_width}, {tile_height})

--- a/aseprite_mcp/tools/transform.py
+++ b/aseprite_mcp/tools/transform.py
@@ -1,5 +1,6 @@
 import os
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -33,10 +34,8 @@ async def flip_layer(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])
@@ -150,10 +149,8 @@ async def rotate_layer(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])

--- a/tests/test_group_layers.py
+++ b/tests/test_group_layers.py
@@ -1,0 +1,124 @@
+"""Issue #17: layer lookups must reach layers nested inside groups.
+
+Before the fix every tool resolved a layer by scanning only the sprite's
+top-level layers, so a layer inside a group was unreachable by name. These
+tests build a grouped sprite and assert the operation tools now reach nested
+layers by bare name and by "group/child" path, that a bare name prefers the
+shallower layer when names collide, and that the duplicate-name guard stays
+top-level (Aseprite permits the same name in different groups).
+"""
+import pytest
+
+from conftest import BASE, ok, run
+
+from aseprite_mcp.tools import (
+    animation,
+    canvas,
+    drawing,
+    layers,
+    pixel_read,
+    tilemap,
+    transform,
+)
+from aseprite_mcp.core.commands import AsepriteCommand
+
+
+@pytest.fixture(scope="module")
+def nested(base_dir):
+    """A sprite with GRP{inside}, top-level outer, and a 'dupe' in both places."""
+    path = f"{BASE}/group_layers.aseprite"
+    ok(run(canvas.create_canvas(16, 16, path)))
+    setup = """
+    local spr = app.activeSprite
+    local grp = spr:newGroup(); grp.name = "GRP"
+    local inside = spr:newLayer(); inside.name = "inside"; inside.parent = grp
+    spr:newCel(inside, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    local outer = spr:newLayer(); outer.name = "outer"
+    local d1 = spr:newLayer(); d1.name = "dupe"
+    local d2 = spr:newLayer(); d2.name = "dupe"; d2.parent = grp
+    spr:saveAs(spr.filename)
+    """
+    success, out = AsepriteCommand.execute_lua_script(setup, path)
+    assert success, out
+    return path
+
+
+def test_draw_reaches_nested_by_name(nested):
+    ok(run(drawing.draw_rectangle_at(nested, "inside", 1, 0, 0, 4, 4, "#ffffff", True)))
+
+
+def test_draw_reaches_nested_by_path(nested):
+    ok(run(drawing.draw_rectangle_at(nested, "GRP/inside", 1, 2, 2, 4, 4, "#00ff00", True)))
+
+
+def test_visibility_reaches_nested(nested):  # animation.py converted loop
+    ok(run(animation.set_layer_visibility(nested, "inside", False)))
+
+
+def test_rename_reaches_nested(nested):  # layers.py via the shared helper
+    ok(run(layers.rename_layer(nested, "outer", "outer_renamed")))
+
+
+def test_flip_reaches_nested(nested):  # transform.py converted loop
+    ok(run(transform.flip_layer(nested, "inside", 1, "horizontal")))
+
+
+def test_pixel_read_reaches_nested(nested):  # pixel_read.py converted loop
+    result = run(pixel_read.get_pixel_color(nested, 0, 0, "inside"))
+    assert not str(result).startswith(("Failed", "ERROR")), result
+
+
+def test_ambiguous_bare_name_prefers_shallow(nested):
+    # 'dupe' exists top-level and inside GRP; the bare name must resolve to the
+    # shallower one, while the path targets the nested namesake.
+    ok(run(drawing.draw_rectangle_at(nested, "dupe", 1, 0, 0, 2, 2, "#ff0000", True)))
+    ok(run(drawing.draw_rectangle_at(nested, "GRP/dupe", 1, 0, 0, 2, 2, "#0000ff", True)))
+
+
+def test_bogus_name_still_fails(nested):
+    result = run(drawing.draw_rectangle_at(nested, "NOPE", 1, 0, 0, 2, 2, "#ffffff", True))
+    assert str(result).startswith(("Failed", "ERROR")), result
+
+
+def test_duplicate_name_across_group_allowed(nested):
+    # 'inside' exists only inside GRP, so creating a top-level layer with that
+    # name must be allowed — the duplicate guard is top-level only.
+    result = run(tilemap.create_tilemap_layer(nested, "inside", 8, 8))
+    assert not str(result).startswith(("Failed", "ERROR")), result
+
+
+@pytest.fixture(scope="module")
+def slashed(base_dir):
+    """Aseprite permits "/" inside a name. Build a group literally named
+    'abc/x' holding child 'y', plus a genuine 'abc' -> 'x' -> 'z' hierarchy
+    that shares the leading token, so path navigation must coexist with
+    "/"-in-name and backtrack when the longest prefix dead-ends."""
+    path = f"{BASE}/slashed_groups.aseprite"
+    ok(run(canvas.create_canvas(16, 16, path)))
+    setup = """
+    local spr = app.activeSprite
+    local g = spr:newGroup(); g.name = "abc/x"
+    local y = spr:newLayer(); y.name = "y"; y.parent = g
+    spr:newCel(y, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    local a = spr:newGroup(); a.name = "abc"
+    local x = spr:newGroup(); x.name = "x"; x.parent = a
+    local z = spr:newLayer(); z.name = "z"; z.parent = x
+    spr:newCel(z, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    spr:saveAs(spr.filename)
+    """
+    success, out = AsepriteCommand.execute_lua_script(setup, path)
+    assert success, out
+    return path
+
+
+def test_child_under_slash_named_group(slashed):
+    # The group is literally named "abc/x"; its child "y" must resolve as
+    # "abc/x/y" — the longest leading group name wins.
+    ok(run(drawing.draw_rectangle_at(slashed, "abc/x/y", 1, 0, 0, 4, 4, "#ffffff", True)))
+
+
+def test_real_path_backtracks_past_slash_name(slashed):
+    # "abc/x/z" must still reach the genuine abc -> x -> z layer: the longest
+    # prefix "abc/x" matches the sibling group but has no child "z", so the
+    # walk backtracks to "abc" -> "x" -> "z".
+    ok(run(drawing.draw_rectangle_at(slashed, "abc/x/z", 1, 0, 0, 4, 4, "#00ff00", True)))


### PR DESCRIPTION
Closes #17.

> **Note:** this branch is stacked on #16 — the first two commits belong to that PR, so they show up in this diff until #16 lands. I'll rebase onto `main` once it does. The commit to review here is the last one (`feat(layers): resolve layer names inside groups`).

## The bug

Every tool resolved a layer by name by scanning only `spr.layers` (the top level), so a layer inside a group was unreachable by name — the call failed with `Layer not found` even though the layer exists.

## The fix

The shared `find_layer` helper (`core/lua.py`) now searches inside groups, breadth-first so a shallower layer wins over a deeper namesake. When names collide across groups, a `group/child` path targets a specific nesting; an exact full-name match (including any `/`) is preferred before the name is read as a path.

The remaining inline `ipairs(spr.layers)` lookups — in `animation`, `drawing`, `transform`, `pixel_read`, `canvas`, `palette`, and `scene` — now go through this helper, so behaviour is uniform. The modules already using the helper (`layers`, `fx`, `selection`, `tilemap`, `export`) become group-aware for free.

## Duplicate-name guard stays top-level

`create_tilemap_layer`'s "name already exists" guard is intentionally kept top-level: the new layer is created at the root, and Aseprite permits the same name in a different group, so a recursive check there would reject valid names.

## Out of scope

- The `quality` analysis tools (`validate_scene`, `audit_animation`, `ensure_layers_present`, `animation_sanitize`) keep their own layer scans: they already carry group-aware logic (`isGroup` / parent / `has_groups`) and build scripts via token substitution rather than the shared helper. Making them group-aware is a separate change with its own tests.
- Creating a layer *into* a named group (the enhancement noted in the issue) is a follow-up PR.

## Tests

New `tests/test_group_layers.py` builds a grouped sprite and checks nested lookup by name and by `group/child` path across the converted tools, shallowest-wins on a colliding name, that a bogus name still fails, and that the duplicate-name guard stays top-level. Full suite green (77 passed) on Aseprite 1.3.17.2 / Linux.
