### PR TITLE
feat(layers): create layers and groups inside a named group

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python MCP server that gives AI assistants full control over [Aseprite](https://www.aseprite.org/) for creating pixel art and animated sprites.
 
-**103 tools across 17 categories** — canvas, drawing, layers, animation, palettes, effects, slices, tilemaps, exports, visual-feedback/analysis tools, and a raw Lua escape hatch. The tool set is designed so an LLM has everything it needs to produce *good* pixel art, not just primitives: shading ramps with hue shifting, ordered dithering, outlines, retro palette presets with quantization, onion-skin renders, and frame diffing for animation work.
+**104 tools across 17 categories** — canvas, drawing, layers, animation, palettes, effects, slices, tilemaps, exports, visual-feedback/analysis tools, and a raw Lua escape hatch. The tool set is designed so an LLM has everything it needs to produce *good* pixel art, not just primitives: shading ramps with hue shifting, ordered dithering, outlines, retro palette presets with quantization, onion-skin renders, and frame diffing for animation work.
 
 ## Example: a swordsman, drawn and animated by Claude
 
@@ -52,7 +52,8 @@ Both were created end-to-end by Claude Fable 5 through this server's MCP tools �
 | Tool | Description |
 |------|-------------|
 | `create_canvas` | Create a new sprite with the given dimensions |
-| `add_layer` | Add a new layer |
+| `add_layer` | Add a new layer, optionally inside a named group |
+| `add_group` | Add a new (optionally nested) group layer |
 | `add_frame` | Append a new frame |
 | `set_frame` | Set the active frame |
 | `set_frame_duration` | Set one frame's duration in ms |
@@ -81,7 +82,7 @@ All `_at` variants target a specific layer/frame and can create the cel on deman
 |------|-------------|
 | `delete_layer` | Delete a layer by name |
 | `rename_layer` | Rename a layer |
-| `duplicate_layer` | Duplicate a layer with all cels, opacity, and blend mode |
+| `duplicate_layer` | Duplicate a layer with all cels, opacity, and blend mode, optionally into a group |
 | `reorder_layer` | Move a layer to a position in the stack |
 | `set_layer_blend_mode` | Set blend mode (multiply, screen, overlay, ... 19 modes) |
 | `merge_layer_down` | Merge a layer into the one below it |

--- a/aseprite_mcp/core/lua.py
+++ b/aseprite_mcp/core/lua.py
@@ -5,14 +5,52 @@ with them should print "ERROR:<message>" to signal failure and be run
 through AsepriteCommand.execute_lua_script_checked.
 """
 
-# Find a top-level layer by name (same convention as the rest of the
-# codebase: groups are not traversed).
+# Resolve a layer by name, searching inside groups.
+#
+#   1. An exact full-name match (including any "/") is tried first, breadth-
+#      first, so a shallower layer wins over a deeper namesake and a layer or
+#      group whose own name contains "/" is reachable directly.
+#   2. Otherwise the name is read as a "group/child" path. Aseprite allows "/"
+#      inside names, so segments are matched longest-prefix-first with
+#      backtracking: "abc/x/y" resolves a group named "abc/x" then child "y",
+#      yet a genuine "abc" -> "x" -> "y" hierarchy still resolves because a
+#      dead-end longer prefix falls back to the shorter one. When two parses
+#      are both valid the longest leading group name wins.
+#
+# Used for *operation* lookups — duplicate-name guards must stay top-level,
+# since Aseprite permits the same name in different groups.
 FIND_LAYER = """
 local function find_layer(spr, name)
-    for _, layer in ipairs(spr.layers) do
+    local queue = {}
+    for _, layer in ipairs(spr.layers) do queue[#queue + 1] = layer end
+    local head = 1
+    while head <= #queue do
+        local layer = queue[head]
+        head = head + 1
         if layer.name == name then return layer end
+        if layer.isGroup then
+            for _, child in ipairs(layer.layers) do queue[#queue + 1] = child end
+        end
     end
-    return nil
+    if not string.find(name, "/", 1, true) then return nil end
+    local segs = {}
+    for segment in string.gmatch(name, "[^/]+") do segs[#segs + 1] = segment end
+    local function resolve(layers, i)
+        for j = #segs, i, -1 do
+            local cand = table.concat(segs, "/", i, j)
+            for _, layer in ipairs(layers) do
+                if layer.name == cand then
+                    if j == #segs then return layer end
+                    if layer.isGroup then
+                        local found = resolve(layer.layers, j + 1)
+                        if found then return found end
+                    end
+                end
+            end
+        end
+        return nil
+    end
+    return resolve(spr.layers, 1)
 end
 """
 

--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -1,6 +1,7 @@
 import os
 import json
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -92,13 +93,8 @@ async def set_layer_visibility(filename: str, layer_name: str, visible: bool = T
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -133,13 +129,8 @@ async def set_layer_opacity(filename: str, layer_name: str, opacity: int) -> str
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -298,13 +289,8 @@ async def set_cel_position(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local idx = {frame_index}
@@ -383,13 +369,8 @@ async def tween_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -465,13 +446,8 @@ async def offset_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -528,10 +504,8 @@ async def create_cel(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -565,10 +539,8 @@ async def clear_cel(filename: str, layer_name: str, frame_index: int) -> str:
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -611,10 +583,8 @@ async def copy_cel(
     if src_idx < 1 or src_idx > #spr.frames then print("ERROR:Source frame out of range") return end
     if dst_idx < 1 or dst_idx > #spr.frames then print("ERROR:Target frame out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -889,15 +859,12 @@ async def propagate_cels(
         print("ERROR:Frame range out of bounds") return
     end
 
+    {FIND_LAYER}
     local name_list = {layers_lua}
     local targets = {{}}
     for _, name in ipairs(name_list) do
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == name then
-                table.insert(targets, layer)
-                break
-            end
-        end
+        local m = find_layer(spr, name)
+        if m then table.insert(targets, m) end
     end
     if #targets == 0 then print("ERROR:No layers found") return end
 
@@ -965,13 +932,8 @@ async def tween_cel_positions_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1062,13 +1024,8 @@ async def oscillate_cel_positions(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1158,13 +1115,8 @@ async def tween_cel_opacity_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1268,13 +1220,8 @@ async def tween_cel_scale_eased(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target_layer = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target_layer = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target_layer = find_layer(spr, "{safe_layer_name}")
     if not target_layer then print("ERROR:Layer not found") return end
 
     local start_idx = {start_frame}
@@ -1458,10 +1405,8 @@ async def set_cel_opacity(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])

--- a/aseprite_mcp/tools/canvas.py
+++ b/aseprite_mcp/tools/canvas.py
@@ -33,24 +33,36 @@ async def create_canvas(width: int, height: int, filename: str = "canvas.aseprit
         return f"Failed to create canvas: {output}"
 
 @mcp.tool()
-async def add_layer(filename: str, layer_name: str) -> str:
+async def add_layer(filename: str, layer_name: str, group: str = "") -> str:
     """Add a new layer to the Aseprite file.
 
     Args:
         filename: Name of the Aseprite file to modify
         layer_name: Name of the new layer
+        group: Optional group to place the new layer inside, by name or
+            "group/subgroup" path (default: top level)
     """
     if not os.path.exists(filename):
         return f"File {filename} not found"
-    
+
     safe_layer_name = lua_escape(layer_name)
+    safe_group = lua_escape(group)
     script = f"""
+    {FIND_LAYER}
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
+    local parent = nil
+    if "{safe_group}" ~= "" then
+        parent = find_layer(spr, "{safe_group}")
+        if not parent then print("ERROR:Group not found") return end
+        if not parent.isGroup then print("ERROR:Target is not a group") return end
+    end
+
     app.transaction(function()
-        spr:newLayer()
-        app.activeLayer.name = "{safe_layer_name}"
+        local lyr = spr:newLayer()
+        lyr.name = "{safe_layer_name}"
+        if parent then lyr.parent = parent end
     end)
 
     spr:saveAs(spr.filename)
@@ -60,9 +72,57 @@ async def add_layer(filename: str, layer_name: str) -> str:
     success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
 
     if success:
-        return f"Layer '{layer_name}' added successfully to {filename}"
+        location = f" inside group '{group}'" if group else ""
+        return f"Layer '{layer_name}' added{location} to {filename}"
     else:
         return f"Failed to add layer: {output}"
+
+@mcp.tool()
+async def add_group(filename: str, group_name: str, parent_group: str = "") -> str:
+    """Add a new, empty group layer.
+
+    Combine with add_layer(group=...) / duplicate_layer(group=...) to build a
+    grouped layer structure.
+
+    Args:
+        filename: Name of the Aseprite file to modify
+        group_name: Name of the new group
+        parent_group: Optional existing group to nest the new group inside, by
+            name or "group/subgroup" path (default: top level)
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+
+    safe_group = lua_escape(group_name)
+    safe_parent = lua_escape(parent_group)
+    script = f"""
+    {FIND_LAYER}
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+
+    local parent = nil
+    if "{safe_parent}" ~= "" then
+        parent = find_layer(spr, "{safe_parent}")
+        if not parent then print("ERROR:Parent group not found") return end
+        if not parent.isGroup then print("ERROR:Target is not a group") return end
+    end
+
+    app.transaction(function()
+        local grp = spr:newGroup()
+        grp.name = "{safe_group}"
+        if parent then grp.parent = parent end
+    end)
+
+    spr:saveAs(spr.filename)
+    print("OK")
+    """
+
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+
+    if success:
+        location = f" inside '{parent_group}'" if parent_group else ""
+        return f"Group '{group_name}' created{location} in {filename}"
+    return f"Failed to create group: {output}"
 
 @mcp.tool()
 async def add_frame(filename: str) -> str:

--- a/aseprite_mcp/tools/canvas.py
+++ b/aseprite_mcp/tools/canvas.py
@@ -1,5 +1,6 @@
 import os
 from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -184,13 +185,8 @@ async def set_layer(filename: str, layer_name: str, create_if_missing: bool = Fa
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    local target = nil
-    for i, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then
-            target = layer
-            break
-        end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
 
     app.transaction(function()
         if not target then

--- a/aseprite_mcp/tools/drawing.py
+++ b/aseprite_mcp/tools/drawing.py
@@ -1,6 +1,7 @@
 import os
 from typing import List, Dict, Any
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -368,10 +369,8 @@ async def draw_pixels_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -469,10 +468,8 @@ async def draw_line_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -535,10 +532,8 @@ async def draw_rectangle_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -598,10 +593,8 @@ async def draw_circle_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -662,10 +655,8 @@ async def fill_area_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -782,10 +773,8 @@ async def draw_polygon(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -886,10 +875,8 @@ async def draw_path(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -964,10 +951,8 @@ async def apply_gradient_rect(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()
@@ -1056,10 +1041,8 @@ async def draw_ellipse_at(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     app.transaction(function()

--- a/aseprite_mcp/tools/layers.py
+++ b/aseprite_mcp/tools/layers.py
@@ -100,16 +100,21 @@ async def rename_layer(filename: str, layer_name: str, new_name: str) -> str:
 
 
 @mcp.tool()
-async def duplicate_layer(filename: str, layer_name: str, new_name: str = "") -> str:
+async def duplicate_layer(
+    filename: str, layer_name: str, new_name: str = "", group: str = ""
+) -> str:
     """Duplicate a layer with all its cels across every frame.
 
-    The copy is placed directly above the source layer and inherits its
-    opacity and blend mode.
+    The copy inherits the source's opacity and blend mode. By default it is
+    placed directly above the source layer; pass `group` to place it inside a
+    group instead.
 
     Args:
         filename: Aseprite file to modify
-        layer_name: Layer to duplicate
+        layer_name: Layer to duplicate, by name or "group/subgroup/layer" path
         new_name: Name for the copy (default: "<layer_name> copy")
+        group: Optional group to place the copy inside, by name or
+            "group/subgroup" path (default: directly above the source)
     """
     if not os.path.exists(filename):
         return f"File {filename} not found"
@@ -117,6 +122,7 @@ async def duplicate_layer(filename: str, layer_name: str, new_name: str = "") ->
     final_name = new_name or f"{layer_name} copy"
     safe_layer = lua_escape(layer_name)
     safe_new = lua_escape(final_name)
+    safe_group = lua_escape(group)
     script = f"""
     {FIND_LAYER}
     local spr = app.activeSprite
@@ -125,12 +131,23 @@ async def duplicate_layer(filename: str, layer_name: str, new_name: str = "") ->
     local src = find_layer(spr, "{safe_layer}")
     if not src then print("ERROR:Layer not found") return end
 
+    local parent = nil
+    if "{safe_group}" ~= "" then
+        parent = find_layer(spr, "{safe_group}")
+        if not parent then print("ERROR:Group not found") return end
+        if not parent.isGroup then print("ERROR:Target is not a group") return end
+    end
+
     app.transaction(function()
         local copy = spr:newLayer()
         copy.name = "{safe_new}"
         copy.opacity = src.opacity
         copy.blendMode = src.blendMode
-        copy.stackIndex = src.stackIndex + 1
+        if parent then
+            copy.parent = parent
+        else
+            copy.stackIndex = src.stackIndex + 1
+        end
         for _, frame in ipairs(spr.frames) do
             local cel = src:cel(frame)
             if cel then
@@ -146,7 +163,8 @@ async def duplicate_layer(filename: str, layer_name: str, new_name: str = "") ->
 
     success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
     if success:
-        return f"Layer '{layer_name}' duplicated as '{final_name}' in {filename}"
+        location = f" inside group '{group}'" if group else ""
+        return f"Layer '{layer_name}' duplicated as '{final_name}'{location} in {filename}"
     return f"Failed to duplicate layer: {output}"
 
 

--- a/aseprite_mcp/tools/palette.py
+++ b/aseprite_mcp/tools/palette.py
@@ -167,10 +167,8 @@ async def remap_colors_in_cel_range(
         print("ERROR:Frame range out of bounds") return
     end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer_name}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer_name}")
     if not target then print("ERROR:Layer not found") return end
 
     local source_frame = {source_idx}

--- a/aseprite_mcp/tools/pixel_read.py
+++ b/aseprite_mcp/tools/pixel_read.py
@@ -1,6 +1,7 @@
 import json
 import os
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -34,10 +35,8 @@ async def get_pixel_color(
 
     local cel = nil
     if "{safe_layer}" ~= "" then
-        local target = nil
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == "{safe_layer}" then target = layer break end
-        end
+        {FIND_LAYER}
+        local target = find_layer(spr, "{safe_layer}")
         if not target then print("ERROR:Layer not found") return end
         cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end
@@ -119,10 +118,8 @@ async def get_pixels_rect(
 
     local cel = nil
     if "{safe_layer}" ~= "" then
-        local target = nil
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == "{safe_layer}" then target = layer break end
-        end
+        {FIND_LAYER}
+        local target = find_layer(spr, "{safe_layer}")
         if not target then print("ERROR:Layer not found") return end
         cel = target:cel(spr.frames[idx])
         if not cel then print("ERROR:No cel at that layer/frame") return end

--- a/aseprite_mcp/tools/scene.py
+++ b/aseprite_mcp/tools/scene.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 from ..core.commands import AsepriteCommand, lua_escape, reject_traversal
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 @mcp.tool()
@@ -42,12 +43,7 @@ async def copy_layers_between_sprites(
     local dst = app.open("{dst_path}")
     if not dst then print("ERROR:Target sprite not opened") return end
 
-    local function find_layer(spr, name)
-        for _, layer in ipairs(spr.layers) do
-            if layer.name == name then return layer end
-        end
-        return nil
-    end
+    {FIND_LAYER}
 
     local names = {layers_lua}
     local missing = {{}}

--- a/aseprite_mcp/tools/tilemap.py
+++ b/aseprite_mcp/tools/tilemap.py
@@ -51,7 +51,14 @@ async def create_tilemap_layer(
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
-    if find_layer(spr, "{safe_layer}") then print("ERROR:Layer with that name already exists") return end
+    -- Duplicate-name guard is top-level only: the new layer is created at the
+    -- root, and Aseprite permits the same name inside a different group, so a
+    -- recursive find_layer would reject valid names.
+    local name_taken = false
+    for _, layer in ipairs(spr.layers) do
+        if layer.name == "{safe_layer}" then name_taken = true break end
+    end
+    if name_taken then print("ERROR:Layer with that name already exists") return end
 
     app.transaction(function()
         spr.gridBounds = Rectangle(0, 0, {tile_width}, {tile_height})

--- a/aseprite_mcp/tools/transform.py
+++ b/aseprite_mcp/tools/transform.py
@@ -1,5 +1,6 @@
 import os
 from ..core.commands import AsepriteCommand, lua_escape
+from ..core.lua import FIND_LAYER
 from .. import mcp
 
 
@@ -33,10 +34,8 @@ async def flip_layer(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])
@@ -150,10 +149,8 @@ async def rotate_layer(
     local idx = {frame_index}
     if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
 
-    local target = nil
-    for _, layer in ipairs(spr.layers) do
-        if layer.name == "{safe_layer}" then target = layer break end
-    end
+    {FIND_LAYER}
+    local target = find_layer(spr, "{safe_layer}")
     if not target then print("ERROR:Layer not found") return end
 
     local cel = target:cel(spr.frames[idx])

--- a/tests/test_create_into_group.py
+++ b/tests/test_create_into_group.py
@@ -1,0 +1,68 @@
+"""Issue #17 follow-up: create layers and groups inside named groups.
+
+add_layer / duplicate_layer used to create only at the top level; add_group
+did not exist. These tests check that a group can be created (optionally
+nested), that a new or duplicated layer lands inside a named group (resolved
+by name or "group/subgroup" path), and that a bad / non-group target fails.
+"""
+import json
+
+import pytest
+
+from conftest import BASE, ok, run
+from aseprite_mcp.tools import animation, canvas, drawing, layers
+
+
+def _top_level(path):
+    """Map of top-level layer name -> is_group (get_sprite_info is top-level only)."""
+    info = json.loads(run(animation.get_sprite_info(path)))
+    return {layer["name"]: layer["is_group"] for layer in info["layers"]}
+
+
+@pytest.fixture
+def fresh(base_dir, request):
+    path = f"{BASE}/cig_{request.node.name}.aseprite"
+    ok(run(canvas.create_canvas(16, 16, path)))
+    return path
+
+
+def test_add_group_top_level(fresh):
+    ok(run(canvas.add_group(fresh, "GRP")))
+    assert _top_level(fresh).get("GRP") is True
+
+
+def test_add_layer_into_group(fresh):
+    ok(run(canvas.add_group(fresh, "GRP")))
+    ok(run(canvas.add_layer(fresh, "child", "GRP")))
+    assert "child" not in _top_level(fresh), "child must be inside GRP, not top level"
+    # reachable by path and (recursively) by bare name
+    ok(run(drawing.draw_rectangle_at(fresh, "GRP/child", 1, 0, 0, 4, 4, "#ffffff", True)))
+    ok(run(layers.rename_layer(fresh, "child", "child_renamed")))
+
+
+def test_add_group_nested_then_layer_two_deep(fresh):
+    ok(run(canvas.add_group(fresh, "GRP")))
+    ok(run(canvas.add_group(fresh, "SUB", "GRP")))
+    assert "SUB" not in _top_level(fresh), "SUB must be inside GRP"
+    ok(run(canvas.add_layer(fresh, "deep", "GRP/SUB")))
+    ok(run(drawing.draw_rectangle_at(fresh, "GRP/SUB/deep", 1, 0, 0, 2, 2, "#ffffff", True)))
+
+
+def test_duplicate_into_group(fresh):
+    ok(run(canvas.add_layer(fresh, "body")))
+    ok(run(drawing.draw_rectangle_at(fresh, "body", 1, 0, 0, 8, 8, "#D04648", True)))
+    ok(run(canvas.add_group(fresh, "GRP")))
+    ok(run(layers.duplicate_layer(fresh, "body", "body_copy", "GRP")))
+    assert "body_copy" not in _top_level(fresh), "copy must be inside GRP"
+    ok(run(drawing.draw_rectangle_at(fresh, "GRP/body_copy", 1, 0, 0, 2, 2, "#ffffff", True)))
+
+
+def test_add_layer_unknown_group_fails(fresh):
+    result = run(canvas.add_layer(fresh, "child", "NOPE"))
+    assert str(result).startswith(("Failed", "ERROR")), result
+
+
+def test_add_layer_target_not_a_group_fails(fresh):
+    ok(run(canvas.add_layer(fresh, "plain")))  # a normal layer, not a group
+    result = run(canvas.add_layer(fresh, "child", "plain"))
+    assert str(result).startswith(("Failed", "ERROR")), result

--- a/tests/test_group_layers.py
+++ b/tests/test_group_layers.py
@@ -1,0 +1,124 @@
+"""Issue #17: layer lookups must reach layers nested inside groups.
+
+Before the fix every tool resolved a layer by scanning only the sprite's
+top-level layers, so a layer inside a group was unreachable by name. These
+tests build a grouped sprite and assert the operation tools now reach nested
+layers by bare name and by "group/child" path, that a bare name prefers the
+shallower layer when names collide, and that the duplicate-name guard stays
+top-level (Aseprite permits the same name in different groups).
+"""
+import pytest
+
+from conftest import BASE, ok, run
+
+from aseprite_mcp.tools import (
+    animation,
+    canvas,
+    drawing,
+    layers,
+    pixel_read,
+    tilemap,
+    transform,
+)
+from aseprite_mcp.core.commands import AsepriteCommand
+
+
+@pytest.fixture(scope="module")
+def nested(base_dir):
+    """A sprite with GRP{inside}, top-level outer, and a 'dupe' in both places."""
+    path = f"{BASE}/group_layers.aseprite"
+    ok(run(canvas.create_canvas(16, 16, path)))
+    setup = """
+    local spr = app.activeSprite
+    local grp = spr:newGroup(); grp.name = "GRP"
+    local inside = spr:newLayer(); inside.name = "inside"; inside.parent = grp
+    spr:newCel(inside, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    local outer = spr:newLayer(); outer.name = "outer"
+    local d1 = spr:newLayer(); d1.name = "dupe"
+    local d2 = spr:newLayer(); d2.name = "dupe"; d2.parent = grp
+    spr:saveAs(spr.filename)
+    """
+    success, out = AsepriteCommand.execute_lua_script(setup, path)
+    assert success, out
+    return path
+
+
+def test_draw_reaches_nested_by_name(nested):
+    ok(run(drawing.draw_rectangle_at(nested, "inside", 1, 0, 0, 4, 4, "#ffffff", True)))
+
+
+def test_draw_reaches_nested_by_path(nested):
+    ok(run(drawing.draw_rectangle_at(nested, "GRP/inside", 1, 2, 2, 4, 4, "#00ff00", True)))
+
+
+def test_visibility_reaches_nested(nested):  # animation.py converted loop
+    ok(run(animation.set_layer_visibility(nested, "inside", False)))
+
+
+def test_rename_reaches_nested(nested):  # layers.py via the shared helper
+    ok(run(layers.rename_layer(nested, "outer", "outer_renamed")))
+
+
+def test_flip_reaches_nested(nested):  # transform.py converted loop
+    ok(run(transform.flip_layer(nested, "inside", 1, "horizontal")))
+
+
+def test_pixel_read_reaches_nested(nested):  # pixel_read.py converted loop
+    result = run(pixel_read.get_pixel_color(nested, 0, 0, "inside"))
+    assert not str(result).startswith(("Failed", "ERROR")), result
+
+
+def test_ambiguous_bare_name_prefers_shallow(nested):
+    # 'dupe' exists top-level and inside GRP; the bare name must resolve to the
+    # shallower one, while the path targets the nested namesake.
+    ok(run(drawing.draw_rectangle_at(nested, "dupe", 1, 0, 0, 2, 2, "#ff0000", True)))
+    ok(run(drawing.draw_rectangle_at(nested, "GRP/dupe", 1, 0, 0, 2, 2, "#0000ff", True)))
+
+
+def test_bogus_name_still_fails(nested):
+    result = run(drawing.draw_rectangle_at(nested, "NOPE", 1, 0, 0, 2, 2, "#ffffff", True))
+    assert str(result).startswith(("Failed", "ERROR")), result
+
+
+def test_duplicate_name_across_group_allowed(nested):
+    # 'inside' exists only inside GRP, so creating a top-level layer with that
+    # name must be allowed — the duplicate guard is top-level only.
+    result = run(tilemap.create_tilemap_layer(nested, "inside", 8, 8))
+    assert not str(result).startswith(("Failed", "ERROR")), result
+
+
+@pytest.fixture(scope="module")
+def slashed(base_dir):
+    """Aseprite permits "/" inside a name. Build a group literally named
+    'abc/x' holding child 'y', plus a genuine 'abc' -> 'x' -> 'z' hierarchy
+    that shares the leading token, so path navigation must coexist with
+    "/"-in-name and backtrack when the longest prefix dead-ends."""
+    path = f"{BASE}/slashed_groups.aseprite"
+    ok(run(canvas.create_canvas(16, 16, path)))
+    setup = """
+    local spr = app.activeSprite
+    local g = spr:newGroup(); g.name = "abc/x"
+    local y = spr:newLayer(); y.name = "y"; y.parent = g
+    spr:newCel(y, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    local a = spr:newGroup(); a.name = "abc"
+    local x = spr:newGroup(); x.name = "x"; x.parent = a
+    local z = spr:newLayer(); z.name = "z"; z.parent = x
+    spr:newCel(z, spr.frames[1], Image(16, 16, spr.colorMode), Point(0, 0))
+    spr:saveAs(spr.filename)
+    """
+    success, out = AsepriteCommand.execute_lua_script(setup, path)
+    assert success, out
+    return path
+
+
+def test_child_under_slash_named_group(slashed):
+    # The group is literally named "abc/x"; its child "y" must resolve as
+    # "abc/x/y" — the longest leading group name wins.
+    ok(run(drawing.draw_rectangle_at(slashed, "abc/x/y", 1, 0, 0, 4, 4, "#ffffff", True)))
+
+
+def test_real_path_backtracks_past_slash_name(slashed):
+    # "abc/x/z" must still reach the genuine abc -> x -> z layer: the longest
+    # prefix "abc/x" matches the sibling group but has no child "z", so the
+    # walk backtracks to "abc" -> "x" -> "z".
+    ok(run(drawing.draw_rectangle_at(slashed, "abc/x/z", 1, 0, 0, 4, 4, "#00ff00", True)))


### PR DESCRIPTION
Follow-up to #18, implementing the create-into-group enhancement noted in #17.

> **Note:** this branch is stacked on #16 → #18, so the first three commits belong to those PRs and drop out once they land. The commit to review here is the last one (`feat(layers): create layers and groups inside a named group`). I'll rebase onto `main` as #16/#18 merge.

## What

- **`add_group(filename, group_name, parent_group="")`** — new tool; creates an empty group, optionally nested inside an existing group (by name or `group/subgroup` path). Groups were previously only creatable through the raw `run_lua_script` escape hatch.
- **`add_layer(..., group="")`** — an optional `group` places the new layer inside a named group.
- **`duplicate_layer(..., group="")`** — an optional `group` places the copy inside a named group (otherwise unchanged: directly above the source).

Group and source resolution reuse the recursive `find_layer` from #18, so a bare name and a `group/subgroup` path both work. A missing or non-group target fails loudly rather than creating at the top level.

## Tests

`tests/test_create_into_group.py`: create a top-level and a nested group, add a layer into a group and two levels deep via path, duplicate a layer into a group, and reject an unknown / non-group target. Full suite green (83 passed) on Aseprite 1.3.17.2 / Linux. README tool tables updated (104 tools).
