### PR TITLE
feat: composite (flattened) pixel read

### DIFF
--- a/aseprite_mcp/tools/pixel_read.py
+++ b/aseprite_mcp/tools/pixel_read.py
@@ -2,6 +2,7 @@ import json
 import os
 from ..core.commands import AsepriteCommand, lua_escape
 from ..core.lua import FIND_LAYER
+from .analysis import _FLATTEN_FRAME
 from .. import mcp
 
 
@@ -169,6 +170,130 @@ async def get_pixels_rect(
                 "r": r, "g": g, "b": b, "a": a,
             })
 
+    if not pixels:
+        return "No pixel data returned"
+    return json.dumps(pixels)
+
+
+@mcp.tool()
+async def get_composite_pixel(filename: str, x: int, y: int, frame_index: int = 1) -> str:
+    """Read the RGBA colour VISIBLE at a pixel (flattened composite of all layers).
+
+    Unlike get_pixel_color (which reads a single cel), this composites every
+    visible layer — "what the player actually sees" — by flattening a throwaway
+    clone. Essential for value/CVD QA on grouped/multi-layer scenes.
+
+    Args:
+        filename: Aseprite file to read
+        x: X coordinate (sprite-global)
+        y: Y coordinate (sprite-global)
+        frame_index: Frame index starting at 1
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+
+    script = f"""
+    {_FLATTEN_FRAME}
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+    local idx = {frame_index}
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
+    local clone = Sprite(spr)
+    clone:flatten()
+    local img = flatten_frame(clone, idx, nil)
+    local r, g, b, a = 0, 0, 0, 0
+    if {x} >= 0 and {y} >= 0 and {x} < img.width and {y} < img.height then
+        local pv = img:getPixel({x}, {y})
+        r = app.pixelColor.rgbaR(pv)
+        g = app.pixelColor.rgbaG(pv)
+        b = app.pixelColor.rgbaB(pv)
+        a = app.pixelColor.rgbaA(pv)
+    end
+    print(string.format("PIXEL:%d,%d,%d,%d", r, g, b, a))
+    """
+
+    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    if not success:
+        return f"Failed to read composite pixel: {output}"
+    for line in output.splitlines():
+        if line.startswith("ERROR:"):
+            return f"Failed to read composite pixel: {line[6:]}"
+        if line.startswith("PIXEL:"):
+            r, g, b, a = (int(p) for p in line[6:].split(","))
+            return f"#{r:02x}{g:02x}{b:02x} (r={r}, g={g}, b={b}, a={a})"
+    return "No pixel data returned"
+
+
+@mcp.tool()
+async def get_composite_rect(
+    filename: str,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+    frame_index: int = 1,
+) -> str:
+    """Read VISIBLE RGBA over a rectangle (flattened composite of all layers).
+
+    The rectangular counterpart of get_composite_pixel — reads the composited
+    pixels every visible layer produces, not a single cel.
+
+    Args:
+        filename: Aseprite file to read
+        x: Top-left x (sprite-global)
+        y: Top-left y (sprite-global)
+        width: Region width
+        height: Region height
+        frame_index: Frame index starting at 1
+
+    Returns:
+        JSON array of {x, y, hex, r, g, b, a} objects
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    if width <= 0 or height <= 0:
+        return "Width and height must be > 0"
+
+    x_end, y_end = x + width - 1, y + height - 1
+    script = f"""
+    {_FLATTEN_FRAME}
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+    local idx = {frame_index}
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
+    local clone = Sprite(spr)
+    clone:flatten()
+    local img = flatten_frame(clone, idx, nil)
+    local iw, ih = img.width, img.height
+    for py = {y}, {y_end} do
+        for px = {x}, {x_end} do
+            local r, g, b, a = 0, 0, 0, 0
+            if px >= 0 and py >= 0 and px < iw and py < ih then
+                local pv = img:getPixel(px, py)
+                r = app.pixelColor.rgbaR(pv)
+                g = app.pixelColor.rgbaG(pv)
+                b = app.pixelColor.rgbaB(pv)
+                a = app.pixelColor.rgbaA(pv)
+            end
+            print(string.format("PIXEL:%d,%d,%d,%d,%d,%d", px, py, r, g, b, a))
+        end
+    end
+    """
+
+    success, output = AsepriteCommand.execute_lua_script(script, filename)
+    if not success:
+        return f"Failed to read composite pixels: {output}"
+    pixels = []
+    for line in output.splitlines():
+        if line.startswith("ERROR:"):
+            return f"Failed to read composite pixels: {line[6:]}"
+        if line.startswith("PIXEL:"):
+            px, py, r, g, b, a = (int(p) for p in line[6:].split(","))
+            pixels.append({
+                "x": px, "y": py,
+                "hex": f"#{r:02x}{g:02x}{b:02x}",
+                "r": r, "g": g, "b": b, "a": a,
+            })
     if not pixels:
         return "No pixel data returned"
     return json.dumps(pixels)

--- a/tests/test_composite_read.py
+++ b/tests/test_composite_read.py
@@ -1,0 +1,34 @@
+"""Composite (flattened) pixel read (pixel_read.py).
+
+Proves get_composite_* reads the VISIBLE composite (top layer wins),
+unlike get_pixel_color which reads a single named cel.
+"""
+import json
+
+from conftest import ok, run
+
+from aseprite_mcp.tools import canvas, drawing, pixel_read
+
+
+def test_composite_reads_top_layer(sprite):
+    # fixture: 32x32, 'body' layer with a red rect at (8,8,16,16).
+    ok(run(canvas.add_layer(sprite, "overlay")))
+    ok(run(drawing.draw_rectangle_at(sprite, "overlay", 1, 8, 8, 16, 16, "#3050D0", True)))
+    # single-cel read of the bottom 'body' layer = its own colour (red).
+    body = run(pixel_read.get_pixel_color(sprite, 12, 12, "body", 1))
+    assert body.lower().startswith("#d04648"), body
+    # composite read = what is VISIBLE = the top overlay (blue).
+    comp = run(pixel_read.get_composite_pixel(sprite, 12, 12, 1))
+    assert comp.lower().startswith("#3050d0"), comp
+
+
+def test_composite_rect_shape(sprite):
+    px = json.loads(run(pixel_read.get_composite_rect(sprite, 8, 8, 4, 4, 1)))
+    assert len(px) == 16
+    assert all("hex" in p and "a" in p for p in px)
+
+
+def test_composite_pixel_out_of_bounds_is_transparent(sprite):
+    # A pixel far outside any content reads as transparent black.
+    res = run(pixel_read.get_composite_pixel(sprite, 1, 1, 1))
+    assert "a=0" in res, res


### PR DESCRIPTION
## What
Adds `get_composite_pixel` and `get_composite_rect`: read the RGBA actually **visible** at a pixel/rect — the flattened composite of all layers — instead of a single cel (which is what `get_pixel_color` / `get_pixels_rect` return).

## Why
On a multi-layer or grouped sprite there's currently no way to ask "what colour does the player see at (x, y)?". The single-cel read returns the named layer's own pixel, not the composited result. This matters for pixel-level QA/inspection over a finished scene.

## How
Reuses the existing `_FLATTEN_FRAME` helper (clone → flatten → read) — the same pattern `get_color_stats` / `compare_frames` already use. No new infrastructure.

## Tests
`tests/test_composite_read.py` (3): top layer wins over a lower layer; rect shape; an out-of-bounds pixel reads transparent. Green against a real Aseprite.
