### PR TITLE
fix: list_slices crashes on '|' in a slice name

### DIFF
--- a/aseprite_mcp/tools/slices.py
+++ b/aseprite_mcp/tools/slices.py
@@ -158,25 +158,26 @@ async def list_slices(filename: str) -> str:
     if not os.path.exists(filename):
         return f"File {filename} not found"
 
+    # Emit one JSON object per slice (name via Lua %q) instead of a
+    # '|'-delimited line, so a '|' (or comma/colon) in a slice name can no
+    # longer break the parse for the whole sprite.
     script = """
     local spr = app.activeSprite
     if not spr then print("ERROR:No active sprite") return end
 
     for _, slice in ipairs(spr.slices) do
         local b = slice.bounds
-        local line = string.format("SLICE:%s|%d,%d,%d,%d", slice.name, b.x, b.y, b.width, b.height)
+        local parts = {}
+        parts[#parts + 1] = string.format('"name":%s', string.format("%q", slice.name))
+        parts[#parts + 1] = string.format('"x":%d,"y":%d,"width":%d,"height":%d', b.x, b.y, b.width, b.height)
         if slice.center then
             local c = slice.center
-            line = line .. string.format("|%d,%d,%d,%d", c.x, c.y, c.width, c.height)
-        else
-            line = line .. "|"
+            parts[#parts + 1] = string.format('"center":{"x":%d,"y":%d,"width":%d,"height":%d}', c.x, c.y, c.width, c.height)
         end
         if slice.pivot then
-            line = line .. string.format("|%d,%d", slice.pivot.x, slice.pivot.y)
-        else
-            line = line .. "|"
+            parts[#parts + 1] = string.format('"pivot":{"x":%d,"y":%d}', slice.pivot.x, slice.pivot.y)
         end
-        print(line)
+        print("SLICE:{" .. table.concat(parts, ",") .. "}")
     end
     print("DONE")
     """
@@ -189,16 +190,7 @@ async def list_slices(filename: str) -> str:
     for line in output.splitlines():
         if not line.startswith("SLICE:"):
             continue
-        name, bounds, center, pivot = line[len("SLICE:"):].split("|")
-        bx, by, bw, bh = [int(v) for v in bounds.split(",")]
-        entry = {"name": name, "x": bx, "y": by, "width": bw, "height": bh}
-        if center:
-            cx, cy, cw, ch = [int(v) for v in center.split(",")]
-            entry["center"] = {"x": cx, "y": cy, "width": cw, "height": ch}
-        if pivot:
-            px, py = [int(v) for v in pivot.split(",")]
-            entry["pivot"] = {"x": px, "y": py}
-        slices.append(entry)
+        slices.append(json.loads(line[len("SLICE:"):]))
     return json.dumps(slices)
 
 

--- a/tests/test_slices_pipe.py
+++ b/tests/test_slices_pipe.py
@@ -1,0 +1,16 @@
+"""list_slices must tolerate delimiter characters in a slice name."""
+import json
+
+from conftest import ok, run
+
+from aseprite_mcp.tools import slices
+
+
+def test_list_slices_handles_pipe_and_comma_in_name(sprite):
+    ok(run(slices.create_slice(sprite, "weird|name,x", 1, 2, 10, 12)))
+    ok(run(slices.create_slice(sprite, "ninepatch", 0, 0, 16, 16)))
+    ok(run(slices.set_slice_center(sprite, "ninepatch", 4, 4, 8, 8)))
+    by_name = {s["name"]: s for s in json.loads(ok(run(slices.list_slices(sprite))))}
+    assert "weird|name,x" in by_name
+    assert by_name["weird|name,x"]["x"] == 1 and by_name["weird|name,x"]["width"] == 10
+    assert by_name["ninepatch"]["center"] == {"x": 4, "y": 4, "width": 8, "height": 8}


### PR DESCRIPTION
## Bug
`list_slices` builds one `SLICE:name|x,y,w,h|...|...` line per slice and splits it on `|` in Python. Any `|` in a **slice name** yields too many fields → `ValueError: too many values to unpack`, which aborts the listing for the **whole sprite** (not just the offending slice). Commas/colons in names are similarly fragile.

## Fix
Emit one JSON object per slice from Lua (name via `string.format("%q", ...)`) and `json.loads` each line. No delimiter to collide with the name.

## Tests
`tests/test_slices_pipe.py`: a slice named `weird|name,x` plus a 9-patch (bounds + center) round-trip through `list_slices`. Green against a real Aseprite.
