### PR TITLE
feat: get_sprite_info enumerates group children (parent field)

### DIFF
--- a/aseprite_mcp/tools/animation.py
+++ b/aseprite_mcp/tools/animation.py
@@ -179,13 +179,21 @@ async def get_sprite_info(filename: str) -> str:
     end
     table.insert(parts, "],")
     table.insert(parts, "\\"layers\\":[")
-    for i, layer in ipairs(spr.layers) do
-        local entry = "{\\"name\\":" .. string.format("%q", layer.name) .. ",\\"visible\\":" .. tostring(layer.isVisible) .. ",\\"opacity\\":" .. (layer.opacity or 255) .. ",\\"is_group\\":" .. tostring(layer.isGroup) .. "}"
-        table.insert(parts, entry)
-        if i < #spr.layers then
-            table.insert(parts, ",")
+    -- Recurse into groups so nested layers are enumerated too; each entry
+    -- carries its immediate parent group name (null at top level).
+    local first_layer = true
+    local function walk_layers(layers, parent)
+        for _, layer in ipairs(layers) do
+            if not first_layer then table.insert(parts, ",") end
+            first_layer = false
+            local pj = "null"
+            if parent then pj = string.format("%q", parent) end
+            local entry = "{\\"name\\":" .. string.format("%q", layer.name) .. ",\\"visible\\":" .. tostring(layer.isVisible) .. ",\\"opacity\\":" .. (layer.opacity or 255) .. ",\\"is_group\\":" .. tostring(layer.isGroup) .. ",\\"parent\\":" .. pj .. "}"
+            table.insert(parts, entry)
+            if layer.isGroup then walk_layers(layer.layers, layer.name) end
         end
     end
+    walk_layers(spr.layers, nil)
     table.insert(parts, "],")
     local dirs = {[0]="forward", "reverse", "pingpong", "pingpong_reverse"}
     table.insert(parts, "\\"tags\\":[")

--- a/tests/test_create_into_group.py
+++ b/tests/test_create_into_group.py
@@ -14,9 +14,14 @@ from aseprite_mcp.tools import animation, canvas, drawing, layers
 
 
 def _top_level(path):
-    """Map of top-level layer name -> is_group (get_sprite_info is top-level only)."""
+    """Map of top-level layer name -> is_group.
+
+    get_sprite_info now enumerates nested layers too (each with a "parent"),
+    so filter to parent==None for the top level.
+    """
     info = json.loads(run(animation.get_sprite_info(path)))
-    return {layer["name"]: layer["is_group"] for layer in info["layers"]}
+    return {layer["name"]: layer["is_group"]
+            for layer in info["layers"] if layer.get("parent") is None}
 
 
 @pytest.fixture

--- a/tests/test_sprite_info_groups.py
+++ b/tests/test_sprite_info_groups.py
@@ -1,0 +1,18 @@
+"""get_sprite_info enumerates nested (grouped) layers with a parent field."""
+import json
+
+from conftest import ok, run
+
+from aseprite_mcp.tools import animation, canvas
+
+
+def test_get_sprite_info_enumerates_group_children(sprite):
+    ok(run(canvas.add_group(sprite, "grp")))
+    ok(run(canvas.add_layer(sprite, "child", "grp")))
+    layers = json.loads(run(animation.get_sprite_info(sprite)))["layers"]
+    names = [l["name"] for l in layers]
+    assert "grp" in names and "child" in names  # nested layer enumerated
+    child = next(l for l in layers if l["name"] == "child")
+    assert child["parent"] == "grp"
+    grp = next(l for l in layers if l["name"] == "grp")
+    assert grp["is_group"] is True and grp["parent"] is None


### PR DESCRIPTION
## Problem
`get_sprite_info` iterated only top-level `spr.layers`, so any layer nested inside a group was **absent** from the returned JSON. After the group support landed (#18/#19) a grouped sprite is fully mutable but not fully *inspectable* — you can't see the nested layer names.

## Fix
Recurse into `layer.layers` and emit every layer (including group children), each with an immediate `"parent"` group name (`null` at top level). Existing fields (`name`/`visible`/`opacity`/`is_group`) are unchanged, so this is additive for flat sprites.

## Note
`tests/test_create_into_group.py`'s `_top_level()` helper had treated the (previously top-level-only) output as "the top-level layers"; it now filters `parent is None`.

## Tests
`tests/test_sprite_info_groups.py`: a nested `child` layer is enumerated with `parent == "grp"`; the group reports `parent == null`. Existing group tests still green against a real Aseprite.
