### PR TITLE
feat: native app.command filter wrappers (outline/quantize/adjust/convolution)

### DIFF
--- a/aseprite_mcp/core/native.py
+++ b/aseprite_mcp/core/native.py
@@ -1,0 +1,55 @@
+"""Shared wrapper for native Aseprite `app.command.*` filters.
+
+Native engine commands act on the ACTIVE sprite / layer / frame (and the
+active selection for region scope), NOT on explicit arguments — so the
+wrapper resolves + activates the target BEFORE the command, error-first,
+or a filter silently hits the wrong layer. Verified headless under
+`--batch` with `{ui=false}` (T0, 2026-06-18).
+"""
+from .lua import FIND_LAYER
+from .commands import lua_escape
+
+
+def build_native_command_script(
+    command_lua: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    region: tuple[int, int, int, int] | None = None,
+) -> str:
+    """Wrap an `app.command.X{ui=false,...}` snippet with target activation,
+    an optional selection scope, a transaction, save, and the ERROR:/OK
+    protocol used by the checked-execution path.
+
+    Args:
+        command_lua: the `app.command.X{ui=false, ...}` Lua line(s)
+        layer_name: layer to activate first (empty = leave active layer)
+        frame_index: 1-based frame to activate
+        region: optional (x, y, w, h) to scope the command via a selection
+    """
+    safe_layer = lua_escape(layer_name)
+    if region is not None:
+        x, y, w, h = region
+        sel_set = f"spr.selection = Selection(Rectangle({x}, {y}, {w}, {h}))"
+        sel_clear = "spr.selection:deselect()"
+    else:
+        sel_set = sel_clear = ""
+    return f"""
+    {FIND_LAYER}
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+    local idx = {frame_index}
+    if idx < 1 or idx > #spr.frames then print("ERROR:Frame index out of range") return end
+    app.activeFrame = spr.frames[idx]
+    if "{safe_layer}" ~= "" then
+        local target = find_layer(spr, "{safe_layer}")
+        if not target then print("ERROR:Layer not found") return end
+        app.activeLayer = target
+    end
+    {sel_set}
+    app.transaction(function()
+{command_lua}
+    end)
+    {sel_clear}
+    spr:saveAs(spr.filename)
+    print("OK")
+    """

--- a/aseprite_mcp/tools/__init__.py
+++ b/aseprite_mcp/tools/__init__.py
@@ -16,3 +16,4 @@ from . import analysis
 from . import slices
 from . import tilemap
 from . import script
+from . import native_fx

--- a/aseprite_mcp/tools/native_fx.py
+++ b/aseprite_mcp/tools/native_fx.py
@@ -1,0 +1,274 @@
+"""Native Aseprite filter/command wrappers (app.command.*).
+
+These delegate to Aseprite's own engine filters instead of hand-rolling
+pixel math in Lua — higher quality and faster than the equivalents in
+fx.py. All verified to run headless under --batch (T0, 2026-06-18). They
+are added ALONGSIDE the hand-rolled tools (outline_cel / adjust_hsl /
+quantize_to_palette stay) per the "deprecate, don't break" policy.
+
+General value (upstream-able): nothing Chimera-specific here.
+"""
+import json
+import os
+
+from ..core.commands import AsepriteCommand, lua_escape
+from ..core.native import build_native_command_script
+from .fx import _parse_hex_color
+from .. import mcp
+
+# Built-in convolution-matrix resource names (Aseprite data/convmatr.def).
+CONVOLUTION_MATRICES = frozenset({
+    "brightness", "contrast", "negative",
+    "blur-3x3", "blur-3x3-hard", "blur-5x5", "blur-7x7", "blur-9x9", "blur-17x17",
+    "blur-5x3-left", "blur-17x3-left", "blur-3x17-top",
+    "blur-5x5-diagonal(\\)", "blur-5x5-diagonal(/)",
+    "sharpen-3x3", "sharpen-5x5", "sharpen-7x7",
+    "edges-find", "edges-find-horizontal", "edges-find-vertical",
+    "misc-contour", "misc-texturize", "misc-emboss", "misc-marmolize",
+    "misc-rock", "misc-rock-edges",
+    "drunk-3x3_x", "drunk-3x3_+", "drunk-5x5_x", "drunk-5x5_+",
+    "drunk-7x7_x", "drunk-7x7_+", "drunk-9x9_x", "drunk-9x9_+",
+    "drunk-17x17_x", "drunk-17x17_+", "drunk-17x17_o",
+    "outline-transparent-layer-(cross)", "outline-transparent-layer-(square)",
+})
+
+
+def _region(x: int, y: int, width: int, height: int):
+    return (x, y, width, height) if width > 0 and height > 0 else None
+
+
+@mcp.tool()
+async def outline_native(
+    filename: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    color: str = "#000000",
+    place: str = "outside",
+    matrix: str = "circle",
+) -> str:
+    """Native Aseprite Outline around opaque pixels (app.command.Outline).
+
+    Higher quality than the 1px hand-rolled outline_cel: inside/outside
+    placement + a circle/square brush. Works best on a full-canvas cel.
+
+    Args:
+        filename: Aseprite file to modify
+        layer_name: layer to outline (empty = active layer)
+        frame_index: 1-based frame
+        color: outline colour as #RRGGBB
+        place: "outside" or "inside"
+        matrix: "circle" or "square"
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    rgb = _parse_hex_color(color)
+    if not rgb:
+        return "Invalid color (expected #RRGGBB)"
+    if place not in ("outside", "inside"):
+        return "place must be 'outside' or 'inside'"
+    if matrix not in ("circle", "square"):
+        return "matrix must be 'circle' or 'square'"
+    r, g, b = rgb
+    cmd = (f'        app.command.Outline{{ui=false, color=Color{{r={r}, g={g}, '
+           f'b={b}, a=255}}, place="{place}", matrix="{matrix}"}}')
+    script = build_native_command_script(cmd, layer_name, frame_index)
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success:
+        return f"Outlined ({place}, {matrix}) {layer_name or 'active layer'} in {filename}"
+    return f"Failed to outline: {output}"
+
+
+@mcp.tool()
+async def adjust_hsl_native(
+    filename: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    hue: int = 0,
+    saturation: int = 0,
+    lightness: int = 0,
+    x: int = 0,
+    y: int = 0,
+    width: int = 0,
+    height: int = 0,
+) -> str:
+    """Native Hue/Saturation/Lightness filter (engine-quality vs adjust_hsl).
+
+    Args:
+        filename: Aseprite file to modify
+        layer_name: layer to adjust (empty = active layer)
+        frame_index: 1-based frame
+        hue: -180..180 (degrees)
+        saturation: -100..100
+        lightness: -100..100
+        x, y, width, height: optional region (width>0 & height>0 to scope)
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    if not (-180 <= hue <= 180):
+        return "hue must be -180..180"
+    if not (-100 <= saturation <= 100) or not (-100 <= lightness <= 100):
+        return "saturation and lightness must be -100..100"
+    cmd = (f'        app.command.HueSaturation{{ui=false, hue={hue}, '
+           f'saturation={saturation}, lightness={lightness}, alpha=0}}')
+    script = build_native_command_script(cmd, layer_name, frame_index,
+                                         _region(x, y, width, height))
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success:
+        return f"Adjusted HSL on {layer_name or 'active layer'} in {filename}"
+    return f"Failed to adjust HSL: {output}"
+
+
+@mcp.tool()
+async def adjust_brightness_contrast(
+    filename: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    brightness: int = 0,
+    contrast: int = 0,
+    x: int = 0,
+    y: int = 0,
+    width: int = 0,
+    height: int = 0,
+) -> str:
+    """Native Brightness/Contrast filter (app.command.BrightnessContrast).
+
+    Args:
+        filename: Aseprite file to modify
+        layer_name: layer to adjust (empty = active layer)
+        frame_index: 1-based frame
+        brightness: -100..100
+        contrast: -100..100
+        x, y, width, height: optional region (width>0 & height>0 to scope)
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    if not (-100 <= brightness <= 100) or not (-100 <= contrast <= 100):
+        return "brightness and contrast must be -100..100"
+    cmd = (f'        app.command.BrightnessContrast{{ui=false, '
+           f'brightness={brightness}, contrast={contrast}}}')
+    script = build_native_command_script(cmd, layer_name, frame_index,
+                                         _region(x, y, width, height))
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success:
+        return f"Adjusted brightness/contrast on {layer_name or 'active layer'} in {filename}"
+    return f"Failed to adjust brightness/contrast: {output}"
+
+
+@mcp.tool()
+async def invert_colors(
+    filename: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    x: int = 0,
+    y: int = 0,
+    width: int = 0,
+    height: int = 0,
+) -> str:
+    """Native colour inversion (app.command.InvertColor).
+
+    Args:
+        filename: Aseprite file to modify
+        layer_name: layer to invert (empty = active layer)
+        frame_index: 1-based frame
+        x, y, width, height: optional region (width>0 & height>0 to scope)
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    cmd = "        app.command.InvertColor{ui=false}"
+    script = build_native_command_script(cmd, layer_name, frame_index,
+                                         _region(x, y, width, height))
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success:
+        return f"Inverted colours on {layer_name or 'active layer'} in {filename}"
+    return f"Failed to invert: {output}"
+
+
+@mcp.tool()
+async def apply_convolution(
+    filename: str,
+    matrix: str,
+    layer_name: str = "",
+    frame_index: int = 1,
+    x: int = 0,
+    y: int = 0,
+    width: int = 0,
+    height: int = 0,
+) -> str:
+    """Native convolution filter (blur / sharpen / edge / emboss …).
+
+    Args:
+        filename: Aseprite file to modify
+        matrix: a built-in matrix name (see list_convolution_matrices),
+            e.g. "blur-3x3", "sharpen-3x3", "edges-find", "misc-emboss"
+        layer_name: layer to filter (empty = active layer)
+        frame_index: 1-based frame
+        x, y, width, height: optional region (width>0 & height>0 to scope)
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    if matrix not in CONVOLUTION_MATRICES:
+        return (f"Unknown matrix {matrix!r}; call list_convolution_matrices for "
+                f"the {len(CONVOLUTION_MATRICES)} valid names")
+    cmd = f'        app.command.ConvolutionMatrix{{ui=false, fromResource="{lua_escape(matrix)}"}}'
+    script = build_native_command_script(cmd, layer_name, frame_index,
+                                         _region(x, y, width, height))
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if success:
+        return f"Applied convolution '{matrix}' on {layer_name or 'active layer'} in {filename}"
+    return f"Failed to apply convolution: {output}"
+
+
+@mcp.tool()
+async def list_convolution_matrices() -> str:
+    """List the built-in convolution-matrix names usable with apply_convolution.
+
+    Returns:
+        JSON array of matrix resource names.
+    """
+    return json.dumps(sorted(CONVOLUTION_MATRICES))
+
+
+@mcp.tool()
+async def extract_palette(
+    filename: str,
+    max_colors: int = 16,
+    with_alpha: bool = False,
+) -> str:
+    """Build an OPTIMAL palette from the sprite via native ColorQuantization.
+
+    True palette extraction (vs the nearest-snap quantize_to_palette): writes
+    the resulting palette to the sprite and returns it. NOTE: mutates the
+    sprite's palette. Sprite must be in RGB mode.
+
+    Args:
+        filename: Aseprite file to modify
+        max_colors: palette size cap, 1..256 (fewer if the art has fewer)
+        with_alpha: include alpha when quantizing
+
+    Returns:
+        JSON {colors: [#RRGGBB, ...], count}
+    """
+    if not os.path.exists(filename):
+        return f"File {filename} not found"
+    if not (1 <= max_colors <= 256):
+        return "max_colors must be 1..256"
+    wa = "true" if with_alpha else "false"
+    script = f"""
+    local spr = app.activeSprite
+    if not spr then print("ERROR:No active sprite") return end
+    app.transaction(function()
+        app.command.ColorQuantization{{ui=false, maxColors={max_colors}, withAlpha={wa}}}
+    end)
+    spr:saveAs(spr.filename)
+    local pal = spr.palettes[1]
+    for i = 0, #pal - 1 do
+        local c = pal:getColor(i)
+        print(string.format("PALETTE:#%02X%02X%02X", c.red, c.green, c.blue))
+    end
+    print("OK")
+    """
+    success, output = AsepriteCommand.execute_lua_script_checked(script, filename)
+    if not success:
+        return f"Failed to extract palette: {output}"
+    colors = [ln[len("PALETTE:"):] for ln in output.splitlines() if ln.startswith("PALETTE:")]
+    return json.dumps({"colors": colors, "count": len(colors)})

--- a/tests/test_native_fx.py
+++ b/tests/test_native_fx.py
@@ -1,0 +1,64 @@
+"""Native Aseprite command wrappers (native_fx.py)."""
+import json
+
+from conftest import ok, run
+
+from aseprite_mcp.tools import native_fx, pixel_read
+
+
+def _hex(pixel_result: str) -> str:
+    """Extract the leading '#rrggbb' from get_pixel_color's output."""
+    return str(pixel_result).split()[0].lower()
+
+
+def test_list_convolution_matrices():
+    names = json.loads(run(native_fx.list_convolution_matrices()))
+    assert "blur-3x3" in names
+    assert "sharpen-3x3" in names
+    assert "misc-emboss" in names
+
+
+def test_apply_convolution_rejects_unknown_matrix(sprite):
+    res = run(native_fx.apply_convolution(sprite, "not-a-matrix", "body", 1))
+    assert res.startswith("Unknown matrix")
+
+
+def test_outline_native_inside_colours_the_edge(sprite):
+    # 'body' has a red rect at (8,8)-(23,23). An inside outline recolours the
+    # outer ring, so the left edge at (8, 12) becomes the outline colour.
+    ok(run(native_fx.outline_native(sprite, "body", 1, "#00FF00", "inside", "circle")))
+    edge = run(pixel_read.get_pixel_color(sprite, 8, 12, "body", 1))
+    assert _hex(edge).startswith("#00ff00"), edge
+
+
+def test_invert_colors_is_exact(sprite):
+    before = run(pixel_read.get_pixel_color(sprite, 12, 12, "body", 1))
+    r, g, b = (int(before.split("r=")[1].split(",")[0]),
+               int(before.split("g=")[1].split(",")[0]),
+               int(before.split("b=")[1].split(",")[0]))
+    ok(run(native_fx.invert_colors(sprite, "body", 1)))
+    after = run(pixel_read.get_pixel_color(sprite, 12, 12, "body", 1))
+    expected = f"#{255 - r:02x}{255 - g:02x}{255 - b:02x}"
+    assert _hex(after).startswith(expected), (before, after, expected)
+
+
+def test_adjust_hsl_native(sprite):
+    ok(run(native_fx.adjust_hsl_native(sprite, "body", 1, 40, 0, 0)))
+
+
+def test_adjust_brightness_contrast(sprite):
+    ok(run(native_fx.adjust_brightness_contrast(sprite, "body", 1, 30, 10)))
+
+
+def test_apply_convolution_blur(sprite):
+    ok(run(native_fx.apply_convolution(sprite, "blur-3x3", "body", 1)))
+
+
+def test_adjust_hsl_native_rejects_out_of_range(sprite):
+    assert run(native_fx.adjust_hsl_native(sprite, "body", 1, 999)).startswith("hue must be")
+
+
+def test_extract_palette(sprite):
+    result = json.loads(ok(run(native_fx.extract_palette(sprite, 16))))
+    assert result["count"] >= 1
+    assert all(c.startswith("#") and len(c) == 7 for c in result["colors"])


### PR DESCRIPTION
## What
Adds thin wrappers over Aseprite's native `app.command.*` filters, which are higher quality (and faster) than the hand-rolled Lua equivalents:

- `outline_native` (`Outline`, inside/outside, circle/square) — vs the 1px hand-rolled outline
- `extract_palette` (`ColorQuantization`) — true optimal palette extraction, returns the built palette
- `adjust_hsl_native` (`HueSaturation`), `adjust_brightness_contrast` (`BrightnessContrast`), `invert_colors` (`InvertColor`)
- `apply_convolution` (`ConvolutionMatrix`) + `list_convolution_matrices` (the 38 built-in matrix names: blur/sharpen/edges/emboss/…)

## How
A shared helper `core/native.py:build_native_command_script` does the fiddly-but-critical part: `app.command.*` acts on the **active** sprite/layer/frame, so it resolves + activates the target first (error-first), optionally sets `spr.selection` for a region scope, wraps the command (`ui=false`) in a transaction, saves, and reuses the existing `ERROR:`/`OK` checked-execution protocol. Each tool also accepts optional `x/y/width/height` to scope the filter to a rectangle.

All verified to run headless under `--batch`. **Added alongside** the existing hand-rolled tools — nothing removed.

## Tests
`tests/test_native_fx.py` (9): exact colour inversion (255−channel), inside-outline recolours the edge (proves target activation), HSL/brightness/convolution run, unknown-matrix rejected, `extract_palette` returns a palette. Green against a real Aseprite.
